### PR TITLE
refactor: print less cluttered output

### DIFF
--- a/slk/chain.py
+++ b/slk/chain.py
@@ -515,7 +515,7 @@ def single_node_chain(
         extra_args = []
     server_running = False
     chain = None
-    node = Node(config=config, command_log=command_log, exe=exe)
+    node = Node(config=config, command_log=command_log, exe=exe, name="mainchain")
     try:
         if run_server:
             node.start_server(extra_args, standalone=True, server_out=server_out)

--- a/slk/node.py
+++ b/slk/node.py
@@ -87,7 +87,7 @@ class Node:
         )
         self.pid = self.process.pid
         print(
-            f"started rippled: {self.name} PID: {self.process.pid}",
+            f"  started rippled: {self.name} PID: {self.process.pid}",
             flush=True,
         )
 

--- a/slk/node.py
+++ b/slk/node.py
@@ -13,10 +13,16 @@ class Node:
     """Client to send commands to the rippled server"""
 
     def __init__(
-        self, *, config: ConfigFile, exe: str, command_log: Optional[str] = None
+        self,
+        *,
+        config: ConfigFile,
+        exe: str,
+        command_log: Optional[str] = None,
+        name: str,
     ):
         section = config.port_ws_admin_local
         self.websocket_uri = f"{section.protocol}://{section.ip}:{section.port}"
+        self.name = name
         self.client = WebsocketClient(url=self.websocket_uri)
         self.config = config
         self.exe = exe
@@ -74,14 +80,14 @@ class Node:
         to_run = [self.exe, "--conf", self.config_file_name]
         if standalone:
             to_run.append("-a")
-        print(f"Starting server {self.config_file_name}")
+        print(f"Starting server {self.name}")
         fout = open(server_out, "w")
         self.process = subprocess.Popen(
             to_run + extra_args, stdout=fout, stderr=subprocess.STDOUT
         )
         self.pid = self.process.pid
         print(
-            f"started rippled: config: {self.config_file_name} PID: {self.process.pid}",
+            f"started rippled: {self.name} PID: {self.process.pid}",
             flush=True,
         )
 

--- a/slk/testnet.py
+++ b/slk/testnet.py
@@ -59,8 +59,12 @@ class Sidechain(Chain):
                         continue
                     os.unlink(f)
 
+        node_num = 0
         for config, log in zip(configs, command_logs):
-            node = Node(config=config, command_log=log, exe=exe)
+            node = Node(
+                config=config, command_log=log, exe=exe, name=f"sidechain {node_num}"
+            )
+            node_num += 1
             self.nodes.append(node)
 
         super().__init__(node=self.nodes[0])

--- a/slk/testnet.py
+++ b/slk/testnet.py
@@ -127,6 +127,7 @@ class Sidechain(Chain):
     def wait_for_validated_ledger(self, server_index: Optional[int] = None):
         """Don't return until the network has at least one validated ledger"""
         if server_index is None:
+            print("")  # adds some spacing after the rippled startup messages
             for i in range(len(self.nodes)):
                 self.wait_for_validated_ledger(i)
             return


### PR DESCRIPTION
## High Level Overview of Change

The output that prints out at the start of the `RiplRepl` is hard to parse. This PR cleans it up so it's easier to read.

In order to do that, it adds a new param `name` to `Node` and passes through `params.verbose` to some private helper methods.

### Context of Change

repo cleanup/UX improvements

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

## Before / After

**Before:**
![image](https://user-images.githubusercontent.com/8029314/140186738-3e20ff44-e20c-4b56-8518-c31a758588b1.png)

**After:**
![image](https://user-images.githubusercontent.com/8029314/140183996-98d4be47-c5f8-4070-9def-edcac0b79ad2.png)

## Test Plan

CI passes. RiplRepl works as intended. Tests pass.
