### PR TITLE
refactor: removes `__call__` from `Chain`

### DIFF
--- a/slk/chain.py
+++ b/slk/chain.py
@@ -235,28 +235,6 @@ class Chain:
             result_dict[0] = self.node.request(FederatorInfo())
         return result_dict
 
-    def __call__(
-        self,
-        to_send: Union[Transaction, Request, str],
-        callback: Optional[Callable[[dict], None]] = None,
-    ) -> dict:
-        """Call `send_signed` for transactions or `request` for requests"""
-        if isinstance(to_send, Subscribe):
-            if callback is None:
-                raise ValueError("Subsription requires callback")
-            return self.send_subscribe(to_send, callback)
-        assert callback is None
-        if isinstance(to_send, Transaction):
-            return self.send_signed(to_send)
-        if isinstance(to_send, Request):
-            return self.request(to_send)
-        if isinstance(to_send, dict):
-            return self.request_json(to_send)
-        raise ValueError(
-            "Expected `to_send` to be either a Transaction, Command, or "
-            "SubscriptionCommand"
-        )
-
     def get_configs(self) -> List[ConfigFile]:
         return [self.node.config]
 

--- a/slk/chain.py
+++ b/slk/chain.py
@@ -249,7 +249,7 @@ class Chain:
     def maybe_ledger_accept(self):
         if not self.standalone:
             return
-        self(LedgerAccept())
+        self.request(LedgerAccept())
 
     def get_balances(
         self,

--- a/slk/chain.py
+++ b/slk/chain.py
@@ -189,9 +189,7 @@ class Chain:
         """Send the JSON command to the rippled server"""
         return self.node.request_json(req)
 
-    def send_subscribe_command(
-        self, req: Subscribe, callback: Callable[[dict], None]
-    ) -> dict:
+    def send_subscribe(self, req: Subscribe, callback: Callable[[dict], None]) -> dict:
         """Send the subscription command to the rippled server."""
         if not self.node.client.is_open():
             self.node.client.open()
@@ -246,7 +244,7 @@ class Chain:
         if isinstance(to_send, Subscribe):
             if callback is None:
                 raise ValueError("Subsription requires callback")
-            return self.send_subscribe_command(to_send, callback)
+            return self.send_subscribe(to_send, callback)
         assert callback is None
         if isinstance(to_send, Transaction):
             return self.send_signed(to_send)

--- a/slk/chain_setup.py
+++ b/slk/chain_setup.py
@@ -25,10 +25,10 @@ def setup_mainchain(
     if setup_user_accounts:
         mc_chain.add_to_keymanager(params.user_account)
 
-    # mc_chain(LogLevel('fatal'))
+    # mc_chain.request(LogLevel('fatal'))
 
     # Allow rippling through the genesis account
-    mc_chain(
+    mc_chain.send_signed(
         AccountSet(
             account=params.genesis_account.account_id,
             set_flag=AccountSetFlag.ASF_DEFAULT_RIPPLE,
@@ -37,7 +37,7 @@ def setup_mainchain(
     mc_chain.maybe_ledger_accept()
 
     # Create and fund the mc door account
-    mc_chain(
+    mc_chain.send_signed(
         Payment(
             account=params.genesis_account.account_id,
             destination=params.mc_door_account.account_id,
@@ -47,7 +47,7 @@ def setup_mainchain(
     mc_chain.maybe_ledger_accept()
 
     # Create a trust line so USD/root account ious can be sent cross chain
-    mc_chain(
+    mc_chain.send_signed(
         TrustSet(
             account=params.mc_door_account.account_id,
             limit_amount=IssuedCurrencyAmount(
@@ -62,7 +62,7 @@ def setup_mainchain(
     divide = 4 * len(params.federators)
     by = 5
     quorum = (divide + by - 1) // by
-    mc_chain(
+    mc_chain.send_signed(
         SignerListSet(
             account=params.mc_door_account.account_id,
             signer_quorum=quorum,
@@ -73,7 +73,7 @@ def setup_mainchain(
         )
     )
     mc_chain.maybe_ledger_accept()
-    mc_chain(
+    mc_chain.send_signed(
         TicketCreate(
             account=params.mc_door_account.account_id,
             source_tag=MAINCHAIN_DOOR_KEEPER,
@@ -81,7 +81,7 @@ def setup_mainchain(
         )
     )
     mc_chain.maybe_ledger_accept()
-    mc_chain(
+    mc_chain.send_signed(
         TicketCreate(
             account=params.mc_door_account.account_id,
             source_tag=SIDECHAIN_DOOR_KEEPER,
@@ -89,7 +89,7 @@ def setup_mainchain(
         )
     )
     mc_chain.maybe_ledger_accept()
-    mc_chain(
+    mc_chain.send_signed(
         TicketCreate(
             account=params.mc_door_account.account_id,
             source_tag=UPDATE_SIGNER_LIST,
@@ -97,7 +97,7 @@ def setup_mainchain(
         )
     )
     mc_chain.maybe_ledger_accept()
-    mc_chain(
+    mc_chain.send_signed(
         AccountSet(
             account=params.mc_door_account.account_id,
             set_flag=AccountSetFlag.ASF_DISABLE_MASTER,
@@ -107,7 +107,7 @@ def setup_mainchain(
 
     if setup_user_accounts:
         # Create and fund a regular user account
-        mc_chain(
+        mc_chain.send_signed(
             Payment(
                 account=params.genesis_account.account_id,
                 destination=params.user_account.account_id,
@@ -124,14 +124,14 @@ def setup_sidechain(
     if setup_user_accounts:
         sc_chain.add_to_keymanager(params.user_account)
 
-    # sc_chain(LogLevel('fatal'))
-    # sc_chain(LogLevel('trace', partition='SidechainFederator'))
+    # sc_chain.send_signed(LogLevel('fatal'))
+    # sc_chain.send_signed(LogLevel('trace', partition='SidechainFederator'))
 
     # set the chain's signer list and disable the master key
     divide = 4 * len(params.federators)
     by = 5
     quorum = (divide + by - 1) // by
-    sc_chain(
+    sc_chain.send_signed(
         SignerListSet(
             account=params.genesis_account.account_id,
             signer_quorum=quorum,
@@ -142,7 +142,7 @@ def setup_sidechain(
         )
     )
     sc_chain.maybe_ledger_accept()
-    sc_chain(
+    sc_chain.send_signed(
         TicketCreate(
             account=params.genesis_account.account_id,
             source_tag=MAINCHAIN_DOOR_KEEPER,
@@ -150,7 +150,7 @@ def setup_sidechain(
         )
     )
     sc_chain.maybe_ledger_accept()
-    sc_chain(
+    sc_chain.send_signed(
         TicketCreate(
             account=params.genesis_account.account_id,
             source_tag=SIDECHAIN_DOOR_KEEPER,
@@ -158,7 +158,7 @@ def setup_sidechain(
         )
     )
     sc_chain.maybe_ledger_accept()
-    sc_chain(
+    sc_chain.send_signed(
         TicketCreate(
             account=params.genesis_account.account_id,
             source_tag=UPDATE_SIGNER_LIST,
@@ -166,7 +166,7 @@ def setup_sidechain(
         )
     )
     sc_chain.maybe_ledger_accept()
-    sc_chain(
+    sc_chain.send_signed(
         AccountSet(
             account=params.genesis_account.account_id,
             set_flag=AccountSetFlag.ASF_DISABLE_MASTER,

--- a/slk/xchain_transfer.py
+++ b/slk/xchain_transfer.py
@@ -17,7 +17,7 @@ def _xchain_transfer(
     to_chain_door: Account,
 ):
     memo = Memo(memo_data=dst.account_id_str_as_hex())
-    from_chain(
+    from_chain.send_signed(
         Payment(
             account=src.account_id,
             destination=from_chain_door.account_id,

--- a/tests/simple_xchain_transfer_test.py
+++ b/tests/simple_xchain_transfer_test.py
@@ -72,7 +72,7 @@ def simple_iou_test(mc_chain: Chain, sc_chain: Chain, params: SidechainParams):
     )
     mc_chain.add_asset_alias(mc_asset, "mcd")  # main chain dollar
     sc_chain.add_asset_alias(sc_asset, "scd")  # side chain dollar
-    mc_chain(
+    mc_chain.send_signed(
         TrustSet(
             account=alice.account_id,
             limit_amount=same_amount_new_value(mc_asset, 1_000_000),
@@ -86,14 +86,14 @@ def simple_iou_test(mc_chain: Chain, sc_chain: Chain, params: SidechainParams):
         )
 
     # create a trust line to alice and pay her USD/root
-    mc_chain(
+    mc_chain.send_signed(
         TrustSet(
             account=alice.account_id,
             limit_amount=same_amount_new_value(mc_asset, 1_000_000),
         )
     )
     mc_chain.maybe_ledger_accept()
-    mc_chain(
+    mc_chain.send_signed(
         Payment(
             account=mc_chain.account_from_alias("root").account_id,
             destination=alice.account_id,
@@ -182,7 +182,7 @@ def setup_accounts(mc_chain: Chain, sc_chain: Chain, params: SidechainParams):
     mc_chain.create_account("carol")
     mc_chain.create_account("deb")
     mc_chain.create_account("ella")
-    mc_chain(
+    mc_chain.send_signed(
         Payment(
             account=params.genesis_account.account_id,
             destination=alice.account_id,

--- a/tests/simple_xchain_transfer_test.py
+++ b/tests/simple_xchain_transfer_test.py
@@ -103,7 +103,7 @@ def simple_iou_test(mc_chain: Chain, sc_chain: Chain, params: SidechainParams):
     mc_chain.maybe_ledger_accept()
 
     # create a trust line for adam
-    sc_chain(
+    sc_chain.send_signed(
         TrustSet(
             account=adam.account_id,
             limit_amount=same_amount_new_value(sc_asset, 1_000_000),

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -26,11 +26,15 @@ def _sc_subscribe_callback(v: dict):
 
 
 def mc_connect_subscription(chain: Chain, door_account: Account):
-    chain(Subscribe(accounts=[door_account.account_id]), _mc_subscribe_callback)
+    chain.send_subscribe(
+        Subscribe(accounts=[door_account.account_id]), _mc_subscribe_callback
+    )
 
 
 def sc_connect_subscription(chain: Chain, door_account: Account):
-    chain(Subscribe(accounts=[door_account.account_id]), _sc_subscribe_callback)
+    chain.send_subscribe(
+        Subscribe(accounts=[door_account.account_id]), _sc_subscribe_callback
+    )
 
 
 def wait_for_balance_change(


### PR DESCRIPTION
## High Level Overview of Change

This PR removes the method `__call__` from `Chain`. This makes it more clear what is happening with each object and how it's being used.

### Context of Change

repo cleanup

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes. RiplRepl works. Tests pass.
