### PR TITLE
refactor: move chain context managers to separate file

### DIFF
--- a/slk/chain/chain.py
+++ b/slk/chain/chain.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-import os
-import time
-from contextlib import contextmanager
-from typing import Any, Callable, Dict, Generator, List, Optional, Set, Union, cast
+from typing import Any, Callable, Dict, List, Optional, Set, Union, cast
 
 from xrpl.models import (
     XRP,
@@ -20,9 +17,7 @@ from xrpl.models.transactions.transaction import Transaction
 from xrpl.utils import drops_to_xrp
 
 from slk.chain.chain_base import ChainBase
-from slk.chain.node import Node
 from slk.classes.common import Account
-from slk.classes.config_file import ConfigFile
 
 
 class Chain(ChainBase):
@@ -236,35 +231,3 @@ def balances_data(
             chain_res["account"] = chain_short_name + " " + chain_res["account"]
         result += chain_result
     return result
-
-
-# Start a chain with a single node
-@contextmanager
-def single_node_chain(
-    *,
-    config: ConfigFile,
-    command_log: Optional[str] = None,
-    server_out: str = os.devnull,
-    run_server: bool = True,
-    exe: str,
-    extra_args: Optional[List[str]] = None,
-) -> Generator[Chain, None, None]:
-    """Start a ripple server and return a chain"""
-    if extra_args is None:
-        extra_args = []
-    server_running = False
-    chain = None
-    node = Node(config=config, command_log=command_log, exe=exe, name="mainchain")
-    try:
-        if run_server:
-            node.start_server(extra_args, standalone=True, server_out=server_out)
-            server_running = True
-            time.sleep(1.5)  # give process time to startup
-
-        chain = Chain(node=node)
-        yield chain
-    finally:
-        if chain:
-            chain.shutdown()
-        if run_server and server_running:
-            node.stop_server()

--- a/slk/chain/context_managers.py
+++ b/slk/chain/context_managers.py
@@ -5,6 +5,7 @@ from typing import Generator, List, Optional
 
 from slk.chain.chain import Chain
 from slk.chain.node import Node
+from slk.chain.sidechain import Sidechain
 from slk.classes.config_file import ConfigFile
 
 
@@ -38,3 +39,32 @@ def single_node_chain(
             chain.shutdown()
         if run_server and server_running:
             node.stop_server()
+
+
+# TODO: rename this method to better represent what it does
+# Start a chain for a network with the config files matched by
+# `config_file_prefix*/rippled.cfg`
+@contextmanager
+def sidechain_network(
+    *,
+    exe: str,
+    configs: List[ConfigFile],
+    command_logs: Optional[List[Optional[str]]] = None,
+    run_server: Optional[List[bool]] = None,
+    extra_args: Optional[List[List[str]]] = None,
+) -> Generator[Chain, None, None]:
+    """Start a ripple testnet and return a chain"""
+    try:
+        chain = None
+        chain = Sidechain(
+            exe,
+            configs,
+            command_logs=command_logs,
+            run_server=run_server,
+            extra_args=extra_args,
+        )
+        chain.wait_for_validated_ledger()
+        yield chain
+    finally:
+        if chain:
+            chain.shutdown()

--- a/slk/chain/context_managers.py
+++ b/slk/chain/context_managers.py
@@ -57,7 +57,7 @@ def sidechain_network(
     try:
         chain = Sidechain(
             exe,
-            configs,
+            configs=configs,
             command_logs=command_logs,
             run_server=run_server,
             extra_args=extra_args,

--- a/slk/chain/context_managers.py
+++ b/slk/chain/context_managers.py
@@ -55,7 +55,6 @@ def sidechain_network(
 ) -> Generator[Chain, None, None]:
     """Start a ripple testnet and return a chain"""
     try:
-        chain = None
         chain = Sidechain(
             exe,
             configs,

--- a/slk/chain/context_managers.py
+++ b/slk/chain/context_managers.py
@@ -1,0 +1,40 @@
+import os
+import time
+from contextlib import contextmanager
+from typing import Generator, List, Optional
+
+from slk.chain.chain import Chain
+from slk.chain.node import Node
+from slk.classes.config_file import ConfigFile
+
+
+# Start a chain with a single node
+@contextmanager
+def single_node_chain(
+    *,
+    config: ConfigFile,
+    command_log: Optional[str] = None,
+    server_out: str = os.devnull,
+    run_server: bool = True,
+    exe: str,
+    extra_args: Optional[List[str]] = None,
+) -> Generator[Chain, None, None]:
+    """Start a ripple server and return a chain"""
+    if extra_args is None:
+        extra_args = []
+    server_running = False
+    chain = None
+    node = Node(config=config, command_log=command_log, exe=exe, name="mainchain")
+    try:
+        if run_server:
+            node.start_server(extra_args, standalone=True, server_out=server_out)
+            server_running = True
+            time.sleep(1.5)  # give process time to startup
+
+        chain = Chain(node=node)
+        yield chain
+    finally:
+        if chain:
+            chain.shutdown()
+        if run_server and server_running:
+            node.stop_server()

--- a/slk/chain/sidechain.py
+++ b/slk/chain/sidechain.py
@@ -19,8 +19,8 @@ class Sidechain(Chain):
     def __init__(
         self: Sidechain,
         exe: str,
-        configs: List[ConfigFile],
         *,
+        configs: List[ConfigFile],
         command_logs: Optional[List[Optional[str]]] = None,
         run_server: Optional[List[bool]] = None,
         extra_args: Optional[List[List[str]]] = None,
@@ -39,15 +39,18 @@ class Sidechain(Chain):
         self.running_server_indexes: Set[int] = set()
 
         if run_server is None:
-            run_server = []
-        run_server += [True] * (len(configs) - len(run_server))
-
-        self.run_server = run_server
+            self.run_server = []
+        else:
+            self.run_server = run_server.copy()
+        # fill up the rest of run_server (so there's an element for each node)
+        self.run_server += [True] * (len(configs) - len(self.run_server))
 
         if command_logs is None:
-            command_logs = []
-        command_logs += [None] * (len(configs) - len(command_logs))
-        # TODO: figure out what all these Nones do
+            node_logs: List[Optional[str]] = []
+        else:
+            node_logs = node_logs.copy()
+        # fill up the rest of node_logs (so there's an element for each node)
+        node_logs += [None] * (len(configs) - len(node_logs))
 
         # remove the old database directories.
         # we want tests to start from the same empty state every time
@@ -61,7 +64,7 @@ class Sidechain(Chain):
                     os.unlink(f)
 
         node_num = 0
-        for config, log in zip(configs, command_logs):
+        for config, log in zip(configs, node_logs):
             node = Node(
                 config=config, command_log=log, exe=exe, name=f"sidechain {node_num}"
             )

--- a/slk/chain/sidechain.py
+++ b/slk/chain/sidechain.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 import glob
 import os
 import time
-from contextlib import contextmanager
-from typing import Any, Dict, Generator, List, Optional, Set, Union
+from typing import Any, Dict, List, Optional, Set, Union
 
 from xrpl.models import FederatorInfo
 
@@ -179,32 +178,3 @@ class Sidechain(Chain):
             node = self.nodes[i]
             node.stop_server()
             self.running_server_indexes.discard(i)
-
-
-# TODO: rename this method to better represent what it does
-# Start a chain for a network with the config files matched by
-# `config_file_prefix*/rippled.cfg`
-@contextmanager
-def sidechain_network(
-    *,
-    exe: str,
-    configs: List[ConfigFile],
-    command_logs: Optional[List[Optional[str]]] = None,
-    run_server: Optional[List[bool]] = None,
-    extra_args: Optional[List[List[str]]] = None,
-) -> Generator[Chain, None, None]:
-    """Start a ripple testnet and return a chain"""
-    try:
-        chain = None
-        chain = Sidechain(
-            exe,
-            configs,
-            command_logs=command_logs,
-            run_server=run_server,
-            extra_args=extra_args,
-        )
-        chain.wait_for_validated_ledger()
-        yield chain
-    finally:
-        if chain:
-            chain.shutdown()

--- a/slk/sidechain_interaction.py
+++ b/slk/sidechain_interaction.py
@@ -21,8 +21,7 @@ from typing import Any, Callable, List
 
 from slk.chain.chain import Chain
 from slk.chain.chain_setup import setup_mainchain, setup_sidechain
-from slk.chain.context_managers import single_node_chain
-from slk.chain.sidechain import sidechain_network
+from slk.chain.context_managers import sidechain_network, single_node_chain
 from slk.chain.xchain_transfer import main_to_side_transfer, side_to_main_transfer
 from slk.classes.common import disable_eprint, eprint
 from slk.classes.config_file import ConfigFile

--- a/slk/sidechain_interaction.py
+++ b/slk/sidechain_interaction.py
@@ -65,12 +65,12 @@ def simple_test(mc_chain: Chain, sc_chain: Chain, params: SidechainParams) -> No
 
 def _configs_for_testnet(config_file_prefix: str) -> List[ConfigFile]:
     p = Path(config_file_prefix)
-    dir = p.parent
-    file = p.name
+    folder = p.parent
+    file_name = p.name
     file_names = []
-    for f in os.listdir(dir):
-        cfg = os.path.join(dir, f, "rippled.cfg")
-        if f.startswith(file) and os.path.exists(cfg):
+    for f in os.listdir(folder):
+        cfg = os.path.join(folder, f, "rippled.cfg")
+        if f.startswith(file_name) and os.path.exists(cfg):
             file_names.append(cfg)
     file_names.sort()
     return [ConfigFile(file_name=f) for f in file_names]

--- a/slk/sidechain_interaction.py
+++ b/slk/sidechain_interaction.py
@@ -19,8 +19,9 @@ from multiprocessing import Process, Value
 from pathlib import Path
 from typing import Any, Callable, List
 
-from slk.chain.chain import Chain, single_node_chain
+from slk.chain.chain import Chain
 from slk.chain.chain_setup import setup_mainchain, setup_sidechain
+from slk.chain.context_managers import single_node_chain
 from slk.chain.sidechain import sidechain_network
 from slk.chain.xchain_transfer import main_to_side_transfer, side_to_main_transfer
 from slk.classes.common import disable_eprint, eprint


### PR DESCRIPTION
## High Level Overview of Change

This PR moves the context managers for chains (namely `single_node_chain` and `sidechain_network`) to a separate file, `context_managers.py`.

### Context of Change

repo cleanup

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes. Tests pass. RiplRepl works as desired.
