### PR TITLE
refactor: clean up params

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -442,7 +442,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "snowballstemmer"
-version = "2.1.0"
+version = "2.2.0"
 description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
 category = "dev"
 optional = false
@@ -524,7 +524,7 @@ websockets = {version = ">=9.0.1 <11.0", markers = "python_version >= \"3.7\" an
 type = "git"
 url = "https://github.com/XRPLF/xrpl-py.git"
 reference = "sidechain"
-resolved_reference = "7c9e6cc775beb046aaab60fe56df9e55201929b7"
+resolved_reference = "cdc018df4cbc8191a4b439d7d12389e8b27ed357"
 
 [metadata]
 lock-version = "1.1"
@@ -747,8 +747,8 @@ sniffio = [
     {file = "sniffio-1.2.0.tar.gz", hash = "sha256:c4666eecec1d3f50960c6bdf61ab7bc350648da6c126e3cf6898d8cd4ddcd3de"},
 ]
 snowballstemmer = [
-    {file = "snowballstemmer-2.1.0-py2.py3-none-any.whl", hash = "sha256:b51b447bea85f9968c13b650126a888aabd4cb4463fca868ec596826325dedc2"},
-    {file = "snowballstemmer-2.1.0.tar.gz", hash = "sha256:e997baa4f2e9139951b6f4c631bad912dfd3c792467e2f03d7239464af90e914"},
+    {file = "snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"},
+    {file = "snowballstemmer-2.2.0.tar.gz", hash = "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1"},
 ]
 tabulate = [
     {file = "tabulate-0.8.9-py3-none-any.whl", hash = "sha256:d7c013fe7abbc5e491394e10fa845f8f32fe54f8dc60c6622c6cf482d25d47e4"},

--- a/slk/config/config_params.py
+++ b/slk/config/config_params.py
@@ -14,12 +14,6 @@ def _parse_args() -> argparse.Namespace:
     )
 
     parser.add_argument(
-        "--exe",
-        "-e",
-        help=("path to rippled executable"),
-    )
-
-    parser.add_argument(
         "--usd",
         "-u",
         action="store_true",
@@ -49,17 +43,6 @@ def _parse_args() -> argparse.Namespace:
 class ConfigParams:
     def __init__(self: ConfigParams) -> None:
         args = _parse_args()
-
-        if "RIPPLED_MAINCHAIN_EXE" in os.environ:
-            self.exe = os.environ["RIPPLED_MAINCHAIN_EXE"]
-        if args.exe:
-            self.exe = args.exe
-        # if `self.mainchain_exe` doesn't exist (done this way for typing purposes)
-        if not hasattr(self, "exe"):
-            raise Exception(
-                "Missing exe location. Either set the env variable "
-                "RIPPLED_MAINCHAIN_EXE or use the --exe_mainchain command line switch"
-            )
 
         if "RIPPLED_SIDECHAIN_CFG_DIR" in os.environ:
             self.configs_dir = os.environ["RIPPLED_SIDECHAIN_CFG_DIR"]

--- a/slk/config/config_params.py
+++ b/slk/config/config_params.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import argparse
 import os
 
-from dotenv import load_dotenv
+from dotenv import dotenv_values
 
-load_dotenv()
+_ENV_VARS = {
+    **os.environ,
+    **{key: value for key, value in dotenv_values().items() if value},
+}
 
 
 def _parse_args() -> argparse.Namespace:
@@ -44,8 +47,8 @@ class ConfigParams:
     def __init__(self: ConfigParams) -> None:
         args = _parse_args()
 
-        if "RIPPLED_SIDECHAIN_CFG_DIR" in os.environ:
-            self.configs_dir = os.environ["RIPPLED_SIDECHAIN_CFG_DIR"]
+        if "RIPPLED_SIDECHAIN_CFG_DIR" in _ENV_VARS:
+            self.configs_dir = _ENV_VARS["RIPPLED_SIDECHAIN_CFG_DIR"]
         if args.cfgs_dir:
             self.configs_dir = args.cfgs_dir
         # if `self.configs_dir` doesn't exist (done this way for typing purposes)
@@ -55,8 +58,8 @@ class ConfigParams:
                 "RIPPLED_SIDECHAIN_CFG_DIR or use the --cfgs_dir command line switch"
             )
 
-        if "NUM_FEDERATORS" in os.environ:
-            self.num_federators = int(os.environ["NUM_FEDERATORS"])
+        if "NUM_FEDERATORS" in _ENV_VARS:
+            self.num_federators = int(_ENV_VARS["NUM_FEDERATORS"])
         if args.num_federators:
             self.num_federators = int(args.num_federators)
         # if `self.num_federators` doesn't exist (done this way for typing purposes)

--- a/slk/sidechain_params.py
+++ b/slk/sidechain_params.py
@@ -4,12 +4,15 @@ import argparse
 import os
 from typing import Optional
 
-from dotenv import load_dotenv
+from dotenv import dotenv_values
 
 from slk.classes.account import Account
 from slk.classes.config_file import ConfigFile
 
-load_dotenv()
+_ENV_VARS = {
+    **os.environ,
+    **{key: value for key, value in dotenv_values().items() if value},
+}
 
 
 def _parse_args_helper(parser: argparse.ArgumentParser) -> None:

--- a/slk/sidechain_params.py
+++ b/slk/sidechain_params.py
@@ -127,8 +127,8 @@ class SidechainParams:
             )
 
         # identify mainchain rippled exe file location (for standalone)
-        if "RIPPLED_MAINCHAIN_EXE" in os.environ:
-            self.mainchain_exe = os.environ["RIPPLED_MAINCHAIN_EXE"]
+        if "RIPPLED_MAINCHAIN_EXE" in _ENV_VARS:
+            self.mainchain_exe = _ENV_VARS["RIPPLED_MAINCHAIN_EXE"]
         if args.exe_mainchain:
             self.mainchain_exe = args.exe_mainchain
         # if `self.mainchain_exe` doesn't exist (done this way for typing purposes)
@@ -139,8 +139,8 @@ class SidechainParams:
             )
 
         # identify sidechain rippled exe file location
-        if "RIPPLED_SIDECHAIN_EXE" in os.environ:
-            self.sidechain_exe = os.environ["RIPPLED_SIDECHAIN_EXE"]
+        if "RIPPLED_SIDECHAIN_EXE" in _ENV_VARS:
+            self.sidechain_exe = _ENV_VARS["RIPPLED_SIDECHAIN_EXE"]
         if args.exe_sidechain:
             self.sidechain_exe = args.exe_sidechain
         # if `self.sidechain_exe` doesn't exist (done this way for typing purposes)
@@ -152,8 +152,8 @@ class SidechainParams:
 
         # identify where all the config files are located
         self.configs_dir = None
-        if "RIPPLED_SIDECHAIN_CFG_DIR" in os.environ:
-            self.configs_dir = os.environ["RIPPLED_SIDECHAIN_CFG_DIR"]
+        if "RIPPLED_SIDECHAIN_CFG_DIR" in _ENV_VARS:
+            self.configs_dir = _ENV_VARS["RIPPLED_SIDECHAIN_CFG_DIR"]
         if args.cfgs_dir:
             self.configs_dir = args.cfgs_dir
         if configs_dir is not None:
@@ -167,8 +167,8 @@ class SidechainParams:
 
         # identify directory where hooks files are
         self.hooks_dir = None
-        if "RIPPLED_SIDECHAIN_HOOKS_DIR" in os.environ:
-            self.hooks_dir = os.environ["RIPPLED_SIDECHAIN_HOOKS_DIR"]
+        if "RIPPLED_SIDECHAIN_HOOKS_DIR" in _ENV_VARS:
+            self.hooks_dir = _ENV_VARS["RIPPLED_SIDECHAIN_HOOKS_DIR"]
         if args.hooks_dir:
             self.hooks_dir = args.hooks_dir
 


### PR DESCRIPTION
## High Level Overview of Change

This PR removes the `exe` param from the config params (it's no longer needed) and fixes a bug that didn't allow users to use environment variables instead of the `.env` file.

### Context of Change

repo cleanup, bug found

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change that only restructures code)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes. Tests pass. RiplRepl works. Env vars work. 
