### PR TITLE
refactor: rearrange Chain hierarchy

### DIFF
--- a/slk/chain/chain.py
+++ b/slk/chain/chain.py
@@ -1,23 +1,13 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, List, Optional, Set, Union, cast
+import os
+import time
+from typing import Any, Dict, List, Optional, Set, Union
 
-from xrpl.models import (
-    XRP,
-    AccountInfo,
-    AccountLines,
-    Currency,
-    FederatorInfo,
-    IssuedCurrencyAmount,
-    LedgerAccept,
-    Request,
-    Subscribe,
-)
-from xrpl.models.transactions.transaction import Transaction
+from xrpl.models import FederatorInfo
 
 from slk.chain.chain_base import ChainBase
 from slk.chain.node import Node
-from slk.classes.account import Account
 from slk.classes.config_file import ConfigFile
 
 
@@ -26,11 +16,22 @@ class Chain(ChainBase):
 
     def __init__(
         self: Chain,
-        node: Node,
+        exe: str,
+        *,
+        config: ConfigFile,
+        command_log: Optional[str] = None,
+        run_server: bool = False,
+        extra_args: Optional[List[str]] = None,
+        server_out: str = os.devnull,
     ) -> None:
-        self.node = node
+        node = Node(config=config, command_log=command_log, exe=exe, name="mainchain")
 
-        super().__init__()
+        self.server_running = False
+
+        super().__init__(node)
+
+        if run_server:
+            self.servers_start(extra_args=extra_args, server_out=server_out)
 
     @property
     def standalone(self: Chain) -> bool:
@@ -42,6 +43,7 @@ class Chain(ChainBase):
 
     def shutdown(self: Chain) -> None:
         self.node.shutdown()
+        self.servers_stop()
 
     def get_pids(self: Chain) -> List[int]:
         if pid := self.node.get_pid():
@@ -56,44 +58,31 @@ class Chain(ChainBase):
 
     def servers_start(
         self: Chain,
-        server_indexes: Optional[Union[Set[int], List[int]]] = None,
         *,
-        extra_args: Optional[List[List[str]]] = None,
+        extra_args: Optional[List[str]] = None,
+        server_out: str = os.devnull,
     ) -> None:
-        raise ValueError("Cannot start stand alone server")
+        if extra_args is None:
+            extra_args = []
+
+        if self.server_running:
+            return
+
+        self.node.start_server(
+            standalone=True, extra_args=extra_args, server_out=server_out
+        )
+
+        time.sleep(2)  # give servers time to start
 
     def servers_stop(
         self: Chain, server_indexes: Optional[Union[Set[int], List[int]]] = None
     ) -> None:
-        raise ValueError("Cannot stop stand alone server")
+        if self.server_running:
+            self.node.stop_server()
+            self.server_running = False
 
     def get_configs(self: Chain) -> List[ConfigFile]:
         return [self.node.config]
-
-    def send_signed(self: Chain, txn: Transaction) -> Dict[str, Any]:
-        """Sign then send the given transaction"""
-        if not self.key_manager.is_account(txn.account):
-            raise ValueError("Cannot sign transaction without secret key")
-        account_obj = self.key_manager.get_account(txn.account)
-        return self.node.sign_and_submit(txn, account_obj.wallet)
-
-    def request(self: Chain, req: Request) -> Dict[str, Any]:
-        """Send the command to the rippled server"""
-        return self.node.request(req)
-
-    def send_subscribe(
-        self: Chain, req: Subscribe, callback: Callable[[Dict[str, Any]], None]
-    ) -> Dict[str, Any]:
-        """Send the subscription command to the rippled server."""
-        if not self.node.client.is_open():
-            self.node.client.open()
-        self.node.client.on("transaction", callback)
-        return self.node.request(req)
-
-    def maybe_ledger_accept(self: Chain) -> None:
-        if not self.standalone:
-            return
-        self.request(LedgerAccept())
 
     # Get a dict of the server_state, validated_ledger_seq, and complete_ledgers
     def get_brief_server_info(self: Chain) -> Dict[str, List[Any]]:
@@ -111,138 +100,3 @@ class Chain(ChainBase):
         if server_indexes is not None and 0 in server_indexes:
             result_dict[0] = self.node.request(FederatorInfo())
         return result_dict
-
-    def get_account_info(
-        self: Chain, account: Optional[Account] = None
-    ) -> List[Dict[str, Any]]:
-        """
-        Return a dictionary of account info. If account is None, treat as a
-        wildcard (use address book)
-        """
-        if account is None:
-            known_accounts = self.key_manager.known_accounts()
-            return [d for acc in known_accounts for d in self.get_account_info(acc)]
-        try:
-            result = self.request(AccountInfo(account=account.account_id))
-        except:
-            # TODO: better error checking
-            # Most likely the account does not exist on the ledger. Give a balance of 0.
-            return [
-                {
-                    "account": account.account_id,
-                    "balance": "0",
-                    "flags": 0,
-                    "owner_count": 0,
-                    "previous_txn_id": "NA",
-                    "previous_txn_lgr_seq": -1,
-                    "sequence": -1,
-                }
-            ]
-        if "account_data" not in result:
-            raise ValueError("Bad result from account_info command")
-        info = result["account_data"]
-        for dk in ["LedgerEntryType", "index"]:
-            del info[dk]
-        rename_dict = {
-            "Account": "account",
-            "Balance": "balance",
-            "Flags": "flags",
-            "OwnerCount": "owner_count",
-            "PreviousTxnID": "previous_txn_id",
-            "PreviousTxnLgrSeq": "previous_txn_lgr_seq",
-            "Sequence": "sequence",
-        }
-        for key in rename_dict:
-            if key in info:
-                new_key = rename_dict[key]
-                info[new_key] = info[key]
-                del info[key]
-        return [cast(Dict[str, Any], info)]
-
-    def get_balances(
-        self: Chain,
-        account: Union[Account, List[Account], None] = None,
-        token: Union[Currency, List[Currency]] = XRP(),
-    ) -> List[Dict[str, Any]]:
-        """
-        Return a list of dicts of account balances. If account is None, treat as a
-        wildcard (use address book)
-        """
-        if account is None:
-            account = self.key_manager.known_accounts()
-        if isinstance(account, list):
-            return [d for acc in account for d in self.get_balances(acc, token)]
-        if isinstance(token, list):
-            return [d for ass in token for d in self.get_balances(account, ass)]
-        if isinstance(token, XRP):
-            try:
-                account_info = self.get_account_info(account)[0]
-                needed_data = ["account", "balance"]
-                account_info = {
-                    "account": account_info["account"],
-                    "balance": account_info["balance"],
-                }
-                account_info.update({"currency": "XRP", "peer": "", "limit": ""})
-                return [account_info]
-            except:
-                # TODO: better error handling
-                # Most likely the account does not exist on the ledger. Give a balance
-                # of zero.
-                return [
-                    {
-                        "account": account,
-                        "balance": 0,
-                        "currency": "XRP",
-                        "peer": "",
-                        "limit": "",
-                    }
-                ]
-        else:
-            assert isinstance(token, IssuedCurrencyAmount)  # for typing
-            try:
-                trustlines = self.get_trust_lines(account)
-                trustlines = [
-                    tl
-                    for tl in trustlines
-                    if (tl["peer"] == token.issuer and tl["currency"] == token.currency)
-                ]
-                needed_data = ["account", "balance", "currency", "peer", "limit"]
-                return [
-                    {k: trustline[k] for k in trustline if k in needed_data}
-                    for trustline in trustlines
-                ]
-            except:
-                # TODO: better error handling
-                # Most likely the account does not exist on the ledger. Return an empty
-                # data frame
-                return []
-
-    def get_balance(self: Chain, account: Account, token: Currency) -> str:
-        """Get a balance from a single account in a single token"""
-        try:
-            result = self.get_balances(account, token)
-            return cast(str, result[0]["balance"])
-        except:
-            return "0"
-
-    def get_trust_lines(
-        self: Chain, account: Account, peer: Optional[Account] = None
-    ) -> List[Dict[str, Any]]:
-        """
-        Return a list of dictionaries representing account trust lines. If peer account
-        is None, treat as a wildcard.
-        """
-        if peer is None:
-            result = self.request(AccountLines(account=account.account_id))
-        else:
-            result = self.request(
-                AccountLines(account=account.account_id, peer=peer.account_id)
-            )
-        if "lines" not in result or "account" not in result:
-            raise ValueError("Bad result from account_lines command")
-        address = result["account"]
-        account_lines = result["lines"]
-        for account_line in account_lines:
-            account_line["peer"] = account_line["account"]
-            account_line["account"] = address
-        return cast(List[Dict[str, Any]], account_lines)

--- a/slk/chain/chain.py
+++ b/slk/chain/chain.py
@@ -16,11 +16,59 @@ from xrpl.models import (
 from xrpl.models.transactions.transaction import Transaction
 
 from slk.chain.chain_base import ChainBase
+from slk.chain.node import Node
 from slk.classes.account import Account
+from slk.classes.config_file import ConfigFile
 
 
 class Chain(ChainBase):
     """Representation of one chain (mainchain/sidechain)"""
+
+    def __init__(
+        self: Chain,
+        node: Node,
+    ) -> None:
+        self.node = node
+
+        super().__init__()
+
+    @property
+    def standalone(self: Chain) -> bool:
+        return True
+
+    def get_node(self: Chain, i: Optional[int] = None) -> Node:
+        assert i is None
+        return self.node
+
+    def shutdown(self: Chain) -> None:
+        self.node.shutdown()
+
+    def get_pids(self: Chain) -> List[int]:
+        if pid := self.node.get_pid():
+            return [pid]
+        return []
+
+    def get_running_status(self: Chain) -> List[bool]:
+        if self.node.get_pid():
+            return [True]
+        else:
+            return [False]
+
+    def servers_start(
+        self: Chain,
+        server_indexes: Optional[Union[Set[int], List[int]]] = None,
+        *,
+        extra_args: Optional[List[List[str]]] = None,
+    ) -> None:
+        raise ValueError("Cannot start stand alone server")
+
+    def servers_stop(
+        self: Chain, server_indexes: Optional[Union[Set[int], List[int]]] = None
+    ) -> None:
+        raise ValueError("Cannot stop stand alone server")
+
+    def get_configs(self: Chain) -> List[ConfigFile]:
+        return [self.node.config]
 
     def send_signed(self: Chain, txn: Transaction) -> Dict[str, Any]:
         """Sign then send the given transaction"""

--- a/slk/chain/chain.py
+++ b/slk/chain/chain.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import os
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Dict, List, Optional, Union, cast
+from typing import Any, Callable, Dict, List, Optional, Set, Union, cast
 
 from xrpl.models import (
     XRP,
@@ -20,6 +21,7 @@ from slk.chain.asset_aliases import AssetAliases
 from slk.chain.key_manager import KeyManager
 from slk.chain.node import Node
 from slk.classes.account import Account
+from slk.classes.config_file import ConfigFile
 
 ROOT_ACCOUNT = Account(
     nickname="root",
@@ -44,6 +46,33 @@ class Chain(ABC):
     @property
     @abstractmethod
     def standalone(self: Chain) -> bool:
+        pass
+
+    @abstractmethod
+    def get_pids(self: Chain) -> List[int]:
+        pass
+
+    @abstractmethod
+    def get_running_status(self: Chain) -> List[bool]:
+        pass
+
+    @abstractmethod
+    def get_configs(self: Chain) -> List[ConfigFile]:
+        pass
+
+    @abstractmethod
+    def servers_start(
+        self: Chain,
+        *,
+        server_indexes: Optional[Union[Set[int], List[int]]] = None,
+        server_out: str = os.devnull,
+    ) -> None:
+        pass
+
+    @abstractmethod
+    def servers_stop(
+        self: Chain, server_indexes: Optional[Union[Set[int], List[int]]] = None
+    ) -> None:
         pass
 
     # rippled stuff
@@ -213,6 +242,12 @@ class Chain(ABC):
     # Get a dict of the server_state, validated_ledger_seq, and complete_ledgers
     @abstractmethod
     def get_brief_server_info(self: Chain) -> Dict[str, List[Dict[str, Any]]]:
+        pass
+
+    @abstractmethod
+    def federator_info(
+        self: Chain, server_indexes: Optional[Union[Set[int], List[int]]] = None
+    ) -> Dict[int, Dict[str, Any]]:
         pass
 
     # Account/asset stuff

--- a/slk/chain/chain.py
+++ b/slk/chain/chain.py
@@ -53,11 +53,19 @@ class Chain(ABC):
         pass
 
     @abstractmethod
-    def get_running_status(self: Chain) -> List[bool]:
+    def get_node(self: Chain, i: Optional[int] = None) -> Node:
         pass
 
     @abstractmethod
     def get_configs(self: Chain) -> List[ConfigFile]:
+        pass
+
+    @abstractmethod
+    def get_running_status(self: Chain) -> List[bool]:
+        pass
+
+    @abstractmethod
+    def shutdown(self: Chain) -> None:
         pass
 
     @abstractmethod

--- a/slk/chain/chain_base.py
+++ b/slk/chain/chain_base.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, Set, Union
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List
 
 from xrpl.models import IssuedCurrency
 
 from slk.chain.asset_aliases import AssetAliases
 from slk.chain.key_manager import KeyManager
-from slk.chain.node import Node
 from slk.classes.account import Account
-from slk.classes.config_file import ConfigFile
 
 ROOT_ACCOUNT = Account(
     nickname="root",
@@ -17,53 +16,21 @@ ROOT_ACCOUNT = Account(
 )
 
 
-class ChainBase:
+class ChainBase(ABC):
     """Representation of one chain (mainchain/sidechain)"""
 
     def __init__(
         self: ChainBase,
-        node: Node,
     ) -> None:
-        self.node = node
-
         self.key_manager = KeyManager()
         self.asset_aliases = AssetAliases()
 
         self.key_manager.add(ROOT_ACCOUNT)
 
+    @abstractmethod
     @property
     def standalone(self: ChainBase) -> bool:
-        return True
-
-    def shutdown(self: ChainBase) -> None:
-        self.node.shutdown()
-
-    def get_pids(self: ChainBase) -> List[int]:
-        if pid := self.node.get_pid():
-            return [pid]
-        return []
-
-    def get_running_status(self: ChainBase) -> List[bool]:
-        if self.node.get_pid():
-            return [True]
-        else:
-            return [False]
-
-    def servers_start(
-        self: ChainBase,
-        server_indexes: Optional[Union[Set[int], List[int]]] = None,
-        *,
-        extra_args: Optional[List[List[str]]] = None,
-    ) -> None:
-        raise ValueError("Cannot start stand alone server")
-
-    def servers_stop(
-        self: ChainBase, server_indexes: Optional[Union[Set[int], List[int]]] = None
-    ) -> None:
-        raise ValueError("Cannot stop stand alone server")
-
-    def get_configs(self: ChainBase) -> List[ConfigFile]:
-        return [self.node.config]
+        pass
 
     def create_account(self: ChainBase, name: str) -> Account:
         """Create an account. Use the name as the alias."""
@@ -108,7 +75,3 @@ class ChainBase:
 
     def asset_from_alias(self: ChainBase, name: str) -> IssuedCurrency:
         return self.asset_aliases.asset_from_alias(name)
-
-    def get_node(self: ChainBase, i: Optional[int] = None) -> Node:
-        assert i is None
-        return self.node

--- a/slk/chain/context_managers.py
+++ b/slk/chain/context_managers.py
@@ -16,11 +16,8 @@ def single_node_chain(
     server_out: str = os.devnull,
     run_server: bool = True,
     exe: str,
-    extra_args: Optional[List[str]] = None,
 ) -> Generator[Mainchain, None, None]:
     """Start a ripple server and return a chain"""
-    if extra_args is None:
-        extra_args = []
     chain = None
     try:
         chain = Mainchain(
@@ -28,7 +25,6 @@ def single_node_chain(
             config=config,
             command_log=command_log,
             run_server=run_server,
-            extra_args=extra_args,
             server_out=server_out,
         )
         yield chain
@@ -47,7 +43,6 @@ def sidechain_network(
     configs: List[ConfigFile],
     command_logs: Optional[List[Optional[str]]] = None,
     run_server: Optional[List[bool]] = None,
-    extra_args: Optional[List[List[str]]] = None,
 ) -> Generator[Sidechain, None, None]:
     """Start a ripple testnet and return a chain"""
     try:
@@ -56,7 +51,6 @@ def sidechain_network(
             configs=configs,
             command_logs=command_logs,
             run_server=run_server,
-            extra_args=extra_args,
         )
         chain.wait_for_validated_ledger()
         yield chain

--- a/slk/chain/context_managers.py
+++ b/slk/chain/context_managers.py
@@ -1,10 +1,8 @@
 import os
-import time
 from contextlib import contextmanager
 from typing import Generator, List, Optional
 
 from slk.chain.chain import Chain
-from slk.chain.node import Node
 from slk.chain.sidechain import Sidechain
 from slk.classes.config_file import ConfigFile
 
@@ -23,22 +21,20 @@ def single_node_chain(
     """Start a ripple server and return a chain"""
     if extra_args is None:
         extra_args = []
-    server_running = False
     chain = None
-    node = Node(config=config, command_log=command_log, exe=exe, name="mainchain")
     try:
-        if run_server:
-            node.start_server(extra_args, standalone=True, server_out=server_out)
-            server_running = True
-            time.sleep(1.5)  # give process time to startup
-
-        chain = Chain(node=node)
+        chain = Chain(
+            exe,
+            config=config,
+            command_log=command_log,
+            run_server=run_server,
+            extra_args=extra_args,
+            server_out=server_out,
+        )
         yield chain
     finally:
         if chain:
             chain.shutdown()
-        if run_server and server_running:
-            node.stop_server()
 
 
 # TODO: rename this method to better represent what it does
@@ -52,7 +48,7 @@ def sidechain_network(
     command_logs: Optional[List[Optional[str]]] = None,
     run_server: Optional[List[bool]] = None,
     extra_args: Optional[List[List[str]]] = None,
-) -> Generator[Chain, None, None]:
+) -> Generator[Sidechain, None, None]:
     """Start a ripple testnet and return a chain"""
     try:
         chain = Sidechain(

--- a/slk/chain/context_managers.py
+++ b/slk/chain/context_managers.py
@@ -2,7 +2,7 @@ import os
 from contextlib import contextmanager
 from typing import Generator, List, Optional
 
-from slk.chain.chain import Chain
+from slk.chain.mainchain import Mainchain
 from slk.chain.sidechain import Sidechain
 from slk.classes.config_file import ConfigFile
 
@@ -17,13 +17,13 @@ def single_node_chain(
     run_server: bool = True,
     exe: str,
     extra_args: Optional[List[str]] = None,
-) -> Generator[Chain, None, None]:
+) -> Generator[Mainchain, None, None]:
     """Start a ripple server and return a chain"""
     if extra_args is None:
         extra_args = []
     chain = None
     try:
-        chain = Chain(
+        chain = Mainchain(
             exe,
             config=config,
             command_log=command_log,

--- a/slk/chain/mainchain.py
+++ b/slk/chain/mainchain.py
@@ -36,24 +36,27 @@ class Mainchain(Chain):
     def standalone(self: Mainchain) -> bool:
         return True
 
-    def get_node(self: Mainchain, i: Optional[int] = None) -> Node:
-        assert i is None
-        return self.node
-
-    def shutdown(self: Mainchain) -> None:
-        self.node.shutdown()
-        self.servers_stop()
-
     def get_pids(self: Mainchain) -> List[int]:
         if pid := self.node.get_pid():
             return [pid]
         return []
+
+    def get_node(self: Mainchain, i: Optional[int] = None) -> Node:
+        assert i is None
+        return self.node
+
+    def get_configs(self: Mainchain) -> List[ConfigFile]:
+        return [self.node.config]
 
     def get_running_status(self: Mainchain) -> List[bool]:
         if self.node.get_pid():
             return [True]
         else:
             return [False]
+
+    def shutdown(self: Mainchain) -> None:
+        self.node.shutdown()
+        self.servers_stop()
 
     def servers_start(
         self: Mainchain,
@@ -79,9 +82,6 @@ class Mainchain(Chain):
         if self.server_running:
             self.node.stop_server()
             self.server_running = False
-
-    def get_configs(self: Mainchain) -> List[ConfigFile]:
-        return [self.node.config]
 
     # Get a dict of the server_state, validated_ledger_seq, and complete_ledgers
     def get_brief_server_info(self: Mainchain) -> Dict[str, List[Any]]:

--- a/slk/chain/mainchain.py
+++ b/slk/chain/mainchain.py
@@ -11,11 +11,11 @@ from slk.chain.node import Node
 from slk.classes.config_file import ConfigFile
 
 
-class Chain(ChainBase):
-    """Representation of one chain (mainchain/sidechain)"""
+class Mainchain(ChainBase):
+    """Representation of a mainchain."""
 
     def __init__(
-        self: Chain,
+        self: Mainchain,
         exe: str,
         *,
         config: ConfigFile,
@@ -34,30 +34,30 @@ class Chain(ChainBase):
             self.servers_start(extra_args=extra_args, server_out=server_out)
 
     @property
-    def standalone(self: Chain) -> bool:
+    def standalone(self: Mainchain) -> bool:
         return True
 
-    def get_node(self: Chain, i: Optional[int] = None) -> Node:
+    def get_node(self: Mainchain, i: Optional[int] = None) -> Node:
         assert i is None
         return self.node
 
-    def shutdown(self: Chain) -> None:
+    def shutdown(self: Mainchain) -> None:
         self.node.shutdown()
         self.servers_stop()
 
-    def get_pids(self: Chain) -> List[int]:
+    def get_pids(self: Mainchain) -> List[int]:
         if pid := self.node.get_pid():
             return [pid]
         return []
 
-    def get_running_status(self: Chain) -> List[bool]:
+    def get_running_status(self: Mainchain) -> List[bool]:
         if self.node.get_pid():
             return [True]
         else:
             return [False]
 
     def servers_start(
-        self: Chain,
+        self: Mainchain,
         *,
         extra_args: Optional[List[str]] = None,
         server_out: str = os.devnull,
@@ -75,24 +75,24 @@ class Chain(ChainBase):
         time.sleep(2)  # give servers time to start
 
     def servers_stop(
-        self: Chain, server_indexes: Optional[Union[Set[int], List[int]]] = None
+        self: Mainchain, server_indexes: Optional[Union[Set[int], List[int]]] = None
     ) -> None:
         if self.server_running:
             self.node.stop_server()
             self.server_running = False
 
-    def get_configs(self: Chain) -> List[ConfigFile]:
+    def get_configs(self: Mainchain) -> List[ConfigFile]:
         return [self.node.config]
 
     # Get a dict of the server_state, validated_ledger_seq, and complete_ledgers
-    def get_brief_server_info(self: Chain) -> Dict[str, List[Any]]:
+    def get_brief_server_info(self: Mainchain) -> Dict[str, List[Any]]:
         ret = {}
         for (k, v) in self.node.get_brief_server_info().items():
             ret[k] = [v]
         return ret
 
     def federator_info(
-        self: Chain, server_indexes: Optional[Union[Set[int], List[int]]] = None
+        self: Mainchain, server_indexes: Optional[Union[Set[int], List[int]]] = None
     ) -> Dict[int, Dict[str, Any]]:
         # key is server index. value is federator_info result
         result_dict = {}

--- a/slk/chain/mainchain.py
+++ b/slk/chain/mainchain.py
@@ -21,7 +21,6 @@ class Mainchain(Chain):
         config: ConfigFile,
         command_log: Optional[str] = None,
         run_server: bool = False,
-        extra_args: Optional[List[str]] = None,
         server_out: str = os.devnull,
     ) -> None:
         node = Node(config=config, command_log=command_log, exe=exe, name="mainchain")
@@ -31,7 +30,7 @@ class Mainchain(Chain):
         super().__init__(node)
 
         if run_server:
-            self.servers_start(extra_args=extra_args, server_out=server_out)
+            self.servers_start(server_out=server_out)
 
     @property
     def standalone(self: Mainchain) -> bool:
@@ -59,24 +58,24 @@ class Mainchain(Chain):
     def servers_start(
         self: Mainchain,
         *,
-        extra_args: Optional[List[str]] = None,
+        server_indexes: Optional[Union[Set[int], List[int]]] = None,
         server_out: str = os.devnull,
     ) -> None:
-        if extra_args is None:
-            extra_args = []
+        if server_indexes is not None:
+            raise Exception("Mainchain does not have server indexes.")
 
         if self.server_running:
             return
 
-        self.node.start_server(
-            standalone=True, extra_args=extra_args, server_out=server_out
-        )
+        self.node.start_server(standalone=True, server_out=server_out)
 
         time.sleep(2)  # give servers time to start
 
     def servers_stop(
         self: Mainchain, server_indexes: Optional[Union[Set[int], List[int]]] = None
     ) -> None:
+        if server_indexes is not None:
+            raise Exception("Mainchain does not have server indexes.")
         if self.server_running:
             self.node.stop_server()
             self.server_running = False

--- a/slk/chain/mainchain.py
+++ b/slk/chain/mainchain.py
@@ -6,12 +6,12 @@ from typing import Any, Dict, List, Optional, Set, Union
 
 from xrpl.models import FederatorInfo
 
-from slk.chain.chain_base import ChainBase
+from slk.chain.chain import Chain
 from slk.chain.node import Node
 from slk.classes.config_file import ConfigFile
 
 
-class Mainchain(ChainBase):
+class Mainchain(Chain):
     """Representation of a mainchain."""
 
     def __init__(

--- a/slk/chain/node.py
+++ b/slk/chain/node.py
@@ -90,7 +90,7 @@ class Node:
 
         assert self.process is not None
         self.process.wait()
-        self.pid = -1
+        self.pid = None
 
     def wait_for_validated_ledger(self: Node) -> None:
         for i in range(600):
@@ -126,7 +126,7 @@ class Node:
     # Get a dict of the server_state, validated_ledger_seq, and complete_ledgers
     def get_brief_server_info(self: Node) -> Dict[str, Any]:
         ret = {"server_state": "NA", "ledger_seq": "NA", "complete_ledgers": "NA"}
-        if not self.pid or self.pid == -1:
+        if not self.pid:
             return ret
         r = self.client.request(ServerInfo()).result
         if "info" not in r:

--- a/slk/chain/node.py
+++ b/slk/chain/node.py
@@ -62,11 +62,13 @@ class Node:
 
     def start_server(
         self: Node,
-        extra_args: List[str],
         *,
+        extra_args: Optional[List[str]] = None,
         standalone: bool = False,
         server_out: str = os.devnull,
     ) -> None:
+        if extra_args is None:
+            extra_args = []
         to_run = [self.exe, "--conf", self.config_file_name]
         if standalone:
             to_run.append("-a")

--- a/slk/chain/sidechain.py
+++ b/slk/chain/sidechain.py
@@ -74,18 +74,12 @@ class Sidechain(Chain):
 
         self.servers_start()
 
-    def shutdown(self: Sidechain) -> None:
-        for a in self.nodes:
-            a.shutdown()
-
-        self.servers_stop()
-
     @property
     def standalone(self: Sidechain) -> bool:
         return False
 
-    def num_nodes(self: Sidechain) -> int:
-        return len(self.nodes)
+    def get_pids(self: Sidechain) -> List[int]:
+        return [pid for c in self.nodes if (pid := c.get_pid()) is not None]
 
     # TODO: type this better
     def get_node(self: Sidechain, i: Optional[int] = None) -> Node:
@@ -94,34 +88,6 @@ class Sidechain(Chain):
 
     def get_configs(self: Sidechain) -> List[ConfigFile]:
         return [c.config for c in self.nodes]
-
-    def get_pids(self: Sidechain) -> List[int]:
-        return [pid for c in self.nodes if (pid := c.get_pid()) is not None]
-
-    def federator_info(
-        self: Sidechain, server_indexes: Optional[Union[Set[int], List[int]]] = None
-    ) -> Dict[int, Dict[str, Any]]:
-        # key is server index. value is federator_info result
-        result_dict = {}
-        if server_indexes is None or len(server_indexes) == 0:
-            server_indexes = [i for i in range(self.num_nodes()) if self.is_running(i)]
-        for i in server_indexes:
-            if self.is_running(i):
-                result_dict[i] = self.get_node(i).request(FederatorInfo())
-        return result_dict
-
-    # Get a dict of the server_state, validated_ledger_seq, and complete_ledgers
-    def get_brief_server_info(self: Sidechain) -> Dict[str, List[Dict[str, Any]]]:
-        ret: Dict[str, List[Dict[str, Any]]] = {
-            "server_state": [],
-            "ledger_seq": [],
-            "complete_ledgers": [],
-        }
-        for n in self.nodes:
-            r = n.get_brief_server_info()
-            for (k, v) in r.items():
-                ret[k].append(v)
-        return ret
 
     # returns true if the server is running, false if not. Note, this relies on
     # servers being shut down through the `servers_stop` interface. If a server
@@ -133,11 +99,11 @@ class Sidechain(Chain):
     def is_running(self: Sidechain, index: int) -> bool:
         return index in self.running_server_indexes
 
-    def wait_for_validated_ledger(self: Sidechain) -> None:
-        """Don't return until the network has at least one validated ledger"""
-        print("")  # adds some spacing after the rippled startup messages
-        for i in range(len(self.nodes)):
-            self.nodes[i].wait_for_validated_ledger()
+    def shutdown(self: Sidechain) -> None:
+        for a in self.nodes:
+            a.shutdown()
+
+        self.servers_stop()
 
     def servers_start(
         self: Sidechain,
@@ -176,3 +142,34 @@ class Sidechain(Chain):
             node = self.nodes[i]
             node.stop_server()
             self.running_server_indexes.discard(i)
+
+    def federator_info(
+        self: Sidechain, server_indexes: Optional[Union[Set[int], List[int]]] = None
+    ) -> Dict[int, Dict[str, Any]]:
+        # key is server index. value is federator_info result
+        result_dict = {}
+        if server_indexes is None or len(server_indexes) == 0:
+            server_indexes = [i for i in range(len(self.nodes)) if self.is_running(i)]
+        for i in server_indexes:
+            if self.is_running(i):
+                result_dict[i] = self.get_node(i).request(FederatorInfo())
+        return result_dict
+
+    # Get a dict of the server_state, validated_ledger_seq, and complete_ledgers
+    def get_brief_server_info(self: Sidechain) -> Dict[str, List[Dict[str, Any]]]:
+        ret: Dict[str, List[Dict[str, Any]]] = {
+            "server_state": [],
+            "ledger_seq": [],
+            "complete_ledgers": [],
+        }
+        for n in self.nodes:
+            r = n.get_brief_server_info()
+            for (k, v) in r.items():
+                ret[k].append(v)
+        return ret
+
+    def wait_for_validated_ledger(self: Sidechain) -> None:
+        """Don't return until the network has at least one validated ledger"""
+        print("")  # adds some spacing after the rippled startup messages
+        for i in range(len(self.nodes)):
+            self.nodes[i].wait_for_validated_ledger()

--- a/slk/chain/sidechain.py
+++ b/slk/chain/sidechain.py
@@ -8,12 +8,12 @@ from typing import Any, Dict, List, Optional, Set, Union
 
 from xrpl.models import FederatorInfo
 
-from slk.chain.chain_base import ChainBase
+from slk.chain.chain import Chain
 from slk.chain.node import Node
 from slk.classes.config_file import ConfigFile
 
 
-class Sidechain(ChainBase):
+class Sidechain(Chain):
     # If run_server is None, run all the servers.
     # This is useful to help debugging
     def __init__(

--- a/slk/chain/sidechain.py
+++ b/slk/chain/sidechain.py
@@ -23,7 +23,6 @@ class Sidechain(Chain):
         configs: List[ConfigFile],
         command_logs: Optional[List[Optional[str]]] = None,
         run_server: Optional[List[bool]] = None,
-        extra_args: Optional[List[List[str]]] = None,
     ) -> None:
         if not configs:
             raise ValueError("Must specify at least one config")
@@ -73,7 +72,7 @@ class Sidechain(Chain):
 
         super().__init__(self.nodes[0])
 
-        self.servers_start(extra_args=extra_args)
+        self.servers_start()
 
     def shutdown(self: Sidechain) -> None:
         for a in self.nodes:
@@ -142,23 +141,19 @@ class Sidechain(Chain):
 
     def servers_start(
         self: Sidechain,
-        server_indexes: Optional[Union[Set[int], List[int]]] = None,
         *,
-        extra_args: Optional[List[List[str]]] = None,
+        server_indexes: Optional[Union[Set[int], List[int]]] = None,
+        server_out: str = os.devnull,
     ) -> None:
         if server_indexes is None:
             server_indexes = [i for i in range(len(self.nodes))]
-
-        if extra_args is None:
-            extra_args = []
-        extra_args += [list()] * (len(self.nodes) - len(extra_args))
 
         for i in server_indexes:
             if i in self.running_server_indexes or not self.run_server[i]:
                 continue
 
             node = self.nodes[i]
-            node.start_server(extra_args[i])
+            node.start_server(server_out=server_out)
             self.running_server_indexes.add(i)
 
         time.sleep(2)  # give servers time to start

--- a/slk/chain/sidechain.py
+++ b/slk/chain/sidechain.py
@@ -8,12 +8,12 @@ from typing import Any, Dict, List, Optional, Set, Union
 
 from xrpl.models import FederatorInfo
 
-from slk.chain.chain import Chain
+from slk.chain.chain_base import ChainBase
 from slk.chain.node import Node
 from slk.classes.config_file import ConfigFile
 
 
-class Sidechain(Chain):
+class Sidechain(ChainBase):
     # If run_server is None, run all the servers.
     # This is useful to help debugging
     def __init__(
@@ -71,7 +71,7 @@ class Sidechain(Chain):
             node_num += 1
             self.nodes.append(node)
 
-        super().__init__(node=self.nodes[0])
+        super().__init__(self.nodes[0])
 
         self.servers_start(extra_args=extra_args)
 

--- a/slk/repl/repl.py
+++ b/slk/repl/repl.py
@@ -1107,7 +1107,7 @@ class SidechainRepl(cmd.Cmd):
                     indexes.add(int(arg))
             except:
                 f'Error: server_start bad arguments: {args}. Type "help" for help.'
-        self.sc_chain.servers_start(indexes)
+        self.sc_chain.servers_start(server_indexes=indexes)
 
     def complete_server_start(
         self: SidechainRepl, text: str, line: str, begidx: int, endidx: int


### PR DESCRIPTION
## High Level Overview of Change

This PR rearranges the hierarchy of the chain objects. `Chain` is renamed to `Mainchain`, and now `Mainchain` and `Sidechain` both inherit from `Chain` (formerly `ChainBase`), instead of `Sidechain` inheriting from `Mainchain`. `Chain` now has a bunch of abstract methods so that typing all works out, and took on the methods that `Mainchain` and `Sidechain` shared.

Note: `git` messes up the diff because `chain.py` -> `mainchain.py` and `chain_base.py` -> `chain.py`.

### Context of Change

repo cleanup, making the inheritance structure of the chains actually make sense

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes. RiplRepl works. Tests pass.
