### PR TITLE
fix: fix issue with `ConnectionRefusedError` on startup

### DIFF
--- a/slk/chain/mainchain.py
+++ b/slk/chain/mainchain.py
@@ -72,6 +72,7 @@ class Mainchain(Chain):
 
         self.node.start_server(standalone=True, server_out=server_out)
 
+        # wait until the server has started up
         while not self.node.server_started():
             time.sleep(0.5)
 

--- a/slk/chain/mainchain.py
+++ b/slk/chain/mainchain.py
@@ -73,7 +73,11 @@ class Mainchain(Chain):
         self.node.start_server(standalone=True, server_out=server_out)
 
         # wait until the server has started up
+        counter = 0
         while not self.node.server_started():
+            counter += 1
+            if counter == 20:  # 10 second timeout
+                raise Exception("Timeout: server took too long to start.")
             time.sleep(0.5)
 
     def servers_stop(

--- a/slk/chain/mainchain.py
+++ b/slk/chain/mainchain.py
@@ -72,7 +72,8 @@ class Mainchain(Chain):
 
         self.node.start_server(standalone=True, server_out=server_out)
 
-        time.sleep(2)  # give servers time to start
+        while not self.node.server_started():
+            time.sleep(0.5)
 
     def servers_stop(
         self: Mainchain, server_indexes: Optional[Union[Set[int], List[int]]] = None

--- a/slk/chain/mainchain.py
+++ b/slk/chain/mainchain.py
@@ -71,6 +71,7 @@ class Mainchain(Chain):
             return
 
         self.node.start_server(standalone=True, server_out=server_out)
+        self.server_running = True
 
         # wait until the server has started up
         counter = 0

--- a/slk/chain/node.py
+++ b/slk/chain/node.py
@@ -26,6 +26,8 @@ class Node:
     ) -> None:
         section = config.port_ws_admin_local
         self.websocket_uri = f"{section.protocol}://{section.ip}:{section.port}"
+        self.ip = section.ip
+        self.port = section.port
         self.name = name
         self.client = WebsocketClient(url=self.websocket_uri)
         self.config = config
@@ -91,6 +93,18 @@ class Node:
         assert self.process is not None
         self.process.wait()
         self.pid = None
+
+    def server_started(self: Node) -> bool:
+        import socket
+
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        result = sock.connect_ex((self.ip, int(self.port)))
+        if result == 0:
+            ret_val = True
+        else:
+            ret_val = False
+        sock.close()
+        return ret_val
 
     def wait_for_validated_ledger(self: Node) -> None:
         for i in range(600):

--- a/slk/chain/node.py
+++ b/slk/chain/node.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import socket
 import subprocess
 import time
 from typing import Any, Dict, List, Optional
@@ -95,8 +96,6 @@ class Node:
         self.pid = None
 
     def server_started(self: Node) -> bool:
-        import socket
-
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         result = sock.connect_ex((self.ip, int(self.port)))
         if result == 0:

--- a/slk/chain/node.py
+++ b/slk/chain/node.py
@@ -96,12 +96,16 @@ class Node:
         self.pid = None
 
     def server_started(self: Node) -> bool:
+        """
+        Determine whether the server the node is connected to has started and is ready
+        to accept a WebSocket connection on its port.
+
+        Returns:
+            Whether the socket is open and ready to accept a WebSocket connection.
+        """
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
             result = sock.connect_ex((self.ip, int(self.port)))
-            if result == 0:
-                return True
-            else:
-                return False
+            return result == 0  # means the WS port is open for connections
 
     def wait_for_validated_ledger(self: Node) -> None:
         for i in range(600):

--- a/slk/chain/node.py
+++ b/slk/chain/node.py
@@ -96,14 +96,12 @@ class Node:
         self.pid = None
 
     def server_started(self: Node) -> bool:
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        result = sock.connect_ex((self.ip, int(self.port)))
-        if result == 0:
-            ret_val = True
-        else:
-            ret_val = False
-        sock.close()
-        return ret_val
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            result = sock.connect_ex((self.ip, int(self.port)))
+            if result == 0:
+                return True
+            else:
+                return False
 
     def wait_for_validated_ledger(self: Node) -> None:
         for i in range(600):

--- a/slk/chain/sidechain.py
+++ b/slk/chain/sidechain.py
@@ -122,6 +122,7 @@ class Sidechain(Chain):
             node.start_server(server_out=server_out)
             self.running_server_indexes.add(i)
 
+        # wait until the servers have started up
         while not all([node.server_started() for node in self.nodes]):
             time.sleep(0.5)
 

--- a/slk/chain/sidechain.py
+++ b/slk/chain/sidechain.py
@@ -123,7 +123,11 @@ class Sidechain(Chain):
             self.running_server_indexes.add(i)
 
         # wait until the servers have started up
+        counter = 0
         while not all([node.server_started() for node in self.nodes]):
+            counter += 1
+            if counter == 20:  # 10 second timeout
+                raise Exception("Timeout: servers took too long to start.")
             time.sleep(0.5)
 
     def servers_stop(

--- a/slk/chain/sidechain.py
+++ b/slk/chain/sidechain.py
@@ -122,7 +122,8 @@ class Sidechain(Chain):
             node.start_server(server_out=server_out)
             self.running_server_indexes.add(i)
 
-        time.sleep(2)  # give servers time to start
+        while not all([node.server_started() for node in self.nodes]):
+            time.sleep(0.5)
 
     def servers_stop(
         self: Sidechain, server_indexes: Optional[Union[Set[int], List[int]]] = None


### PR DESCRIPTION
## High Level Overview of Change

This PR fixes an issue where occasionally the SLK would fail on startup because there would be a `ConnectionRefusedError` on the standalone mainchain. This is likely because the server took a little longer to start up than the timeout provided. 

It also fixes an issue where the mainchain wasn't being properly killed after the REPL was killed.

### Context of Change

annoying `ConnectionRefusedError` bug that sometimes showed up on startup

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes. RiplRepl works as intended. Tests pass.
