### PR TITLE
refactor: move client opening to server start-up

### DIFF
--- a/slk/chain/chain_setup.py
+++ b/slk/chain/chain_setup.py
@@ -37,7 +37,6 @@ def setup_mainchain(
         issuer = Account.from_seed("issuer", params.issuer)
         mc_chain.add_to_keymanager(issuer)
 
-        mc_chain.node.client.open()
         if not does_account_exist(issuer.account_id, mc_chain.node.client):
             raise Exception(f"Account {issuer} needs to be funded to exist.")
 
@@ -61,7 +60,6 @@ def setup_mainchain(
         )
         mc_chain.maybe_ledger_accept()
     else:
-        mc_chain.node.client.open()
         if not does_account_exist(
             params.mc_door_account.account_id, mc_chain.node.client
         ):

--- a/slk/chain/external_chain.py
+++ b/slk/chain/external_chain.py
@@ -19,6 +19,7 @@ class ExternalChain(Chain):
     ) -> None:
         pass
         super().__init__(ExternalNode("ws", url, port), add_root=False)
+        self.node.client.open()
 
     @property
     def standalone(self: ExternalChain) -> bool:

--- a/slk/chain/external_node.py
+++ b/slk/chain/external_node.py
@@ -42,8 +42,6 @@ class ExternalNode(Node):
     def sign_and_submit(
         self: ExternalNode, txn: Transaction, wallet: Wallet
     ) -> Dict[str, Any]:
-        if not self.client.is_open():
-            self.client.open()
         autofilled = safe_sign_and_autofill_transaction(txn, wallet, self.client)
         return send_reliable_submission(autofilled, self.client).result
 

--- a/slk/chain/mainchain.py
+++ b/slk/chain/mainchain.py
@@ -81,6 +81,8 @@ class Mainchain(Chain):
                 raise Exception("Timeout: server took too long to start.")
             time.sleep(0.5)
 
+        self.node.client.open()
+
     def servers_stop(
         self: Mainchain, server_indexes: Optional[Union[Set[int], List[int]]] = None
     ) -> None:

--- a/slk/chain/node.py
+++ b/slk/chain/node.py
@@ -55,16 +55,12 @@ class Node:
         return self.pid
 
     def request(self: Node, req: Request) -> Dict[str, Any]:
-        if not self.client.is_open():
-            self.client.open()
         response = self.client.request(req)
         if response.is_successful():
             return response.result
         raise Exception("failed transaction", response.result)
 
     def sign_and_submit(self: Node, txn: Transaction, wallet: Wallet) -> Dict[str, Any]:
-        if not self.client.is_open():
-            self.client.open()
         return safe_sign_and_submit_transaction(txn, wallet, self.client).result
 
     def start_server(

--- a/slk/chain/sidechain.py
+++ b/slk/chain/sidechain.py
@@ -130,6 +130,9 @@ class Sidechain(Chain):
                 raise Exception("Timeout: servers took too long to start.")
             time.sleep(0.5)
 
+        for node in self.nodes:
+            node.client.open()
+
     def servers_stop(
         self: Sidechain, server_indexes: Optional[Union[Set[int], List[int]]] = None
     ) -> None:


### PR DESCRIPTION
## High Level Overview of Change

This PR moves the opening of the node client's to when the server starts up. It is still closed when the servers are shut down. This makes it easier to work with clients (you don't need to check if it's already open, we know it is)/

### Context of Change

Now, we don't need to check if the client is open before using it.

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes. Tests pass.
