### PR TITLE
refactor: remove bootstrap file and directly use env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,9 @@
-# version of rippled to run in standalone mode on the mainchain
-RIPPLED_MAINCHAIN_EXE=
-# version of rippled to run on the sidechain
-RIPPLED_SIDECHAIN_EXE=
+# Config creation environment variables
+# -------------------------------------
 # directory to store all the sidechain config stuff in
 RIPPLED_SIDECHAIN_CFG_DIR=
-
 # number of federators in the sidechain
 NUM_FEDERATORS=
-
 # mainnet node to connect to (use "standalone" or leave blank for standalone mode)
 MAINNET=
 # mainnet port to connect to (should be the WS port). Only used if not in standalone mode.
@@ -15,4 +11,13 @@ MAINNET_PORT=
 # seed for the cross-chain token. Only used not in standalone.
 IOU_ISSUER=
 # seed for the door account. Only used not in standalone.
+# NOTE: this variable is used by chain setup as well
 DOOR_ACCOUNT_SEED=
+
+
+# Environment variables for running a sidechain
+# ---------------------------------------------
+# version of rippled to run in standalone mode on the mainchain
+RIPPLED_MAINCHAIN_EXE=
+# version of rippled to run on the sidechain
+RIPPLED_SIDECHAIN_EXE=

--- a/slk/config/config_params.py
+++ b/slk/config/config_params.py
@@ -142,11 +142,10 @@ class ConfigParams:
                 self.mainnet_port = int(args.mainnet_port)
 
         self.door_seed = None
-        if not self.standalone:
-            if "DOOR_ACCOUNT_SEED" in _ENV_VARS:
-                self.door_seed = _ENV_VARS["DOOR_ACCOUNT_SEED"]
-            if args.door_seed:
-                self.door_seed = args.door_seed
+        if "DOOR_ACCOUNT_SEED" in _ENV_VARS:
+            self.door_seed = _ENV_VARS["DOOR_ACCOUNT_SEED"]
+        if args.door_seed:
+            self.door_seed = args.door_seed
 
         self.usd = args.usd or False
 

--- a/slk/config/network.py
+++ b/slk/config/network.py
@@ -104,6 +104,8 @@ class SidechainNetwork(StandaloneNetwork):
         # TODO: main_account needs to be user-defined for external networks
         if main_door_seed is None:
             self.main_account = Wallet.create(CryptoAlgorithm.SECP256K1)
+            print(f"Door account seed: {self.main_account.seed}")
+            print("Store this in the environment variable `DOOR_ACCOUNT_SEED`")
         else:
             self.main_account = Wallet(main_door_seed, 0)
 

--- a/slk/config/templates/sidechain_bootstrap.jinja
+++ b/slk/config/templates/sidechain_bootstrap.jinja
@@ -1,8 +1,0 @@
-[sidechain]
-mainchain_secret={{ mainchain_secret }}
-
-# first value is federator signing public key, second is the signing pk account
-[sidechain_federators]
-{% for fed in federators -%}
-{{ fed.public_key }} {{ fed.account_id }}
-{% endfor %}

--- a/slk/create_config_files.py
+++ b/slk/create_config_files.py
@@ -26,10 +26,9 @@ from typing import Dict, List, Optional, cast
 
 from jinja2 import Environment, FileSystemLoader
 from xrpl.models import XRP, IssuedCurrency
-from xrpl.wallet import Wallet
 
 from slk.config.config_params import ConfigParams
-from slk.config.helper_classes import Keypair, Ports, XChainAsset
+from slk.config.helper_classes import Ports, XChainAsset
 from slk.config.network import (
     ExternalNetwork,
     Network,
@@ -83,21 +82,6 @@ def _generate_validators_txt(sub_dir: str, validators: List[str]) -> None:
     template_data = {"validators": validators}
 
     with open(sub_dir + "/validators.txt", "w") as f:
-        f.write(template.render(template_data))
-
-
-def _generate_sidechain_bootstrap(
-    sub_dir: str, fed_keys: List[Keypair], mainchain_account: Wallet
-) -> None:
-    template = JINJA_ENV.get_template("sidechain_bootstrap.jinja")
-
-    template_data = {
-        "federators": [fed.to_dict() for fed in fed_keys],
-        "mainchain_secret": mainchain_account.seed,
-    }
-
-    # add the bootstrap file
-    with open(sub_dir + "/sidechain_bootstrap.cfg", "w") as f:
         f.write(template.render(template_data))
 
 
@@ -168,10 +152,6 @@ def _generate_cfg_dirs_sidechain(
             f.write(template.render(template_data))
 
         _generate_validators_txt(sub_dir, validators)
-
-        _generate_sidechain_bootstrap(
-            sub_dir, sidenet.federator_keypairs, sidenet.main_account
-        )
 
 
 # Generate all the config files for a mainchain-sidechain setup.

--- a/slk/sidechain_params.py
+++ b/slk/sidechain_params.py
@@ -235,10 +235,6 @@ class SidechainParams:
             self.sidechain_config = ConfigFile(
                 file_name=f"{self.configs_dir}/main.no_shards.dog.sidechain/rippled.cfg"
             )
-            self.sidechain_bootstrap_config = ConfigFile(
-                file_name=f"{self.configs_dir}/main.no_shards.dog.sidechain/"
-                "sidechain_bootstrap.cfg"
-            )
         else:
             if self.main_standalone:
                 self.mainchain_config = ConfigFile(
@@ -248,10 +244,6 @@ class SidechainParams:
             self.sidechain_config = ConfigFile(
                 file_name=f"{self.configs_dir}/sidechain_testnet/sidechain_0/"
                 "rippled.cfg"
-            )
-            self.sidechain_bootstrap_config = ConfigFile(
-                file_name=f"{self.configs_dir}/sidechain_testnet/sidechain_0/"
-                "sidechain_bootstrap.cfg"
             )
 
         # set up door account

--- a/slk/sidechain_params.py
+++ b/slk/sidechain_params.py
@@ -7,6 +7,8 @@ import os
 from typing import Optional
 
 from dotenv import dotenv_values
+from xrpl.core.addresscodec import decode_account_public_key
+from xrpl.core.keypairs import derive_classic_address
 
 from slk.classes.account import Account
 from slk.classes.config_file import ConfigFile
@@ -103,6 +105,12 @@ def _parse_args_helper(parser: argparse.ArgumentParser) -> None:
             "The WebSocket port for the mainnet network. Defaults to 6005. Ignored if "
             "in standalone."
         ),
+    )
+
+    parser.add_argument(
+        "--door_seed",
+        "-d",
+        help=("The seed of the door account to use on the main network."),
     )
 
 
@@ -246,16 +254,25 @@ class SidechainParams:
                 "sidechain_bootstrap.cfg"
             )
 
-        # set up root/door accounts
+        # set up door account
+        door_seed = None
+        if "DOOR_ACCOUNT_SEED" in _ENV_VARS:
+            door_seed = _ENV_VARS["DOOR_ACCOUNT_SEED"]
+        if args.door_seed:
+            door_seed = args.DOOR_ACCOUNT_SEED
+        if door_seed is None:
+            raise Exception("Must specify a door account seed, for sidechain setup.")
+        self.mc_door_account = Account(
+            account_id=self.sidechain_config.sidechain.mainchain_account,
+            seed=door_seed,
+            nickname="door",
+        )
+
+        # set up root accounts
         self.genesis_account = Account(
             account_id="rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
             seed="snoPBrXtMeMyMHUVTgbuqAfg1SUTb",
             nickname="genesis",
-        )
-        self.mc_door_account = Account(
-            account_id=self.sidechain_config.sidechain.mainchain_account,
-            seed=self.sidechain_bootstrap_config.sidechain.mainchain_secret,
-            nickname="door",
         )
         self.user_account = Account(
             account_id="rJynXY96Vuq6B58pST9K5Ak5KgJ2JcRsQy",
@@ -271,6 +288,6 @@ class SidechainParams:
 
         # set up federators
         self.federators = [
-            line.split()[1].strip()
-            for line in self.sidechain_bootstrap_config.sidechain_federators.get_lines()
+            derive_classic_address(decode_account_public_key(line.strip()).hex())
+            for line in self.sidechain_config.sidechain_federators.get_lines()
         ]

--- a/slk/sidechain_params.py
+++ b/slk/sidechain_params.py
@@ -251,7 +251,7 @@ class SidechainParams:
         if "DOOR_ACCOUNT_SEED" in _ENV_VARS:
             door_seed = _ENV_VARS["DOOR_ACCOUNT_SEED"]
         if args.door_seed:
-            door_seed = args.DOOR_ACCOUNT_SEED
+            door_seed = args.door_seed
         if door_seed is None:
             raise Exception("Must specify a door account seed, for sidechain setup.")
         self.mc_door_account = Account(
@@ -280,6 +280,7 @@ class SidechainParams:
 
         # set up federators
         self.federators = [
+            # convert public key to rAddress format
             derive_classic_address(decode_account_public_key(line.strip()).hex())
             for line in self.sidechain_config.sidechain_federators.get_lines()
         ]


### PR DESCRIPTION
## High Level Overview of Change

The `sidechain_bootstrap.cfg` file is only used by the launch kit, and isn't used directly by rippled. It's more confusing to have it, since it seems like rippled is using it.

### Context of Change

general cleanup

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes. Tests pass.
