### PR TITLE
feat: add scripts for prod sidechain setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,9 +126,7 @@ def multinode_test(params: Params):
     def callback(mc_app: App, sc_app: App):
         my_function(mc_app, sc_app, params)
 
-    sidechain._multinode_with_callback(params,
-                                       callback,
-                                       setup_user_accounts=False)
+    sidechain._multinode_with_callback(params, callback)
 ```
 
 The functions `sidechain.main_to_side_transfer` and `sidechain.side_to_main_transfer` can be used as convenience functions to initiate cross chain transfers. Of course, these transactions can also be initiated with a payment to the door account with the memo data set to the destination account on the destination chain (which is what those convenience functions do under the hood).

--- a/docs/source/tutorials/prod.rst
+++ b/docs/source/tutorials/prod.rst
@@ -29,4 +29,10 @@ Run ``sidechain-config``
 Starting up a sidechain
 -----------------------
 
-Run ``sidechain-shell``
+Spin up the federator servers.
+
+.. TODO: add CLI args to make this easier
+
+Run `slk.chain.chain_setup.setup_prod_mainchain` with the appropriate variables.
+
+Run `slk.chain.chain_setup.setup_prod_sidechain` with the appropriate variables.

--- a/slk/chain/chain_setup.py
+++ b/slk/chain/chain_setup.py
@@ -268,7 +268,7 @@ def setup_prod_sidechain(
     sidechain_url: str,
     sidechain_ws_port: int,
     federators: List[str],
-    sc_door_account: Account,
+    sc_door_account: Account = _GENESIS_ACCOUNT,
 ) -> None:
     """
     Set up a production sidechain.
@@ -277,7 +277,8 @@ def setup_prod_sidechain(
         sidechain_url: The URL/IP address of a node on the sidechain.
         sidechain_ws_port: The WS port of the node.
         federators: A list of the federators' public keys (for multisigning).
-        sc_door_account: The sidechain door account.
+        sc_door_account: The sidechain door account. The default is the genesis
+            account.
     """
     with connect_to_external_chain(
         url=sidechain_url,

--- a/slk/chain/chain_setup.py
+++ b/slk/chain/chain_setup.py
@@ -36,7 +36,7 @@ def _is_door_master_disabled(door_acct: str, client: SyncClient) -> bool:
 def setup_mainchain(
     mc_chain: Chain,
     federators: List[str],
-    mc_door_account: str,
+    mc_door_account: Account,
     params: SidechainParams,
 ) -> None:
     """
@@ -157,7 +157,10 @@ def setup_mainchain(
 
 
 def setup_sidechain(
-    sc_chain: Chain, federators: List[str], params: SidechainParams
+    sc_chain: Chain,
+    federators: List[str],
+    sc_door_account: Account,
+    params: SidechainParams,
 ) -> None:
     """
     Set up the sidechain.
@@ -166,7 +169,7 @@ def setup_sidechain(
         sc_chain: The sidechain.
         params: The command-line arguments for setup.
     """
-    sc_chain.add_to_keymanager(params.sc_door_account)
+    sc_chain.add_to_keymanager(sc_door_account)
 
     # sc_chain.send_signed(LogLevel('fatal'))
     # sc_chain.send_signed(LogLevel('trace', partition='SidechainFederator'))

--- a/slk/chain/chain_setup.py
+++ b/slk/chain/chain_setup.py
@@ -1,5 +1,7 @@
 """Helper methods for setting up chains."""
 
+from typing import List
+
 from xrpl.account import does_account_exist, get_account_root
 from xrpl.clients.sync_client import SyncClient
 from xrpl.models import (
@@ -32,7 +34,7 @@ def _is_door_master_disabled(door_acct: str, client: SyncClient) -> bool:
 
 
 def setup_mainchain(
-    mc_chain: Chain, params: SidechainParams, setup_user_accounts: bool = True
+    mc_chain: Chain, federators: List[str], params: SidechainParams, setup_user_accounts: bool = True
 ) -> None:
     """
     Set up the mainchain.
@@ -108,7 +110,7 @@ def setup_mainchain(
 
     # set the chain's signer list and disable the master key
     # quorum is 80%
-    divide = 4 * len(params.federators)
+    divide = 4 * len(federators)
     by = 5
     quorum = (divide + by - 1) // by
     mc_chain.send_signed(
@@ -117,7 +119,7 @@ def setup_mainchain(
             signer_quorum=quorum,
             signer_entries=[
                 SignerEntry(account=federator, signer_weight=1)
-                for federator in params.federators
+                for federator in federators
             ],
         )
     )
@@ -167,7 +169,7 @@ def setup_mainchain(
 
 
 def setup_sidechain(
-    sc_chain: Chain, params: SidechainParams, setup_user_accounts: bool = True
+    sc_chain: Chain, federators: List[str], params: SidechainParams, setup_user_accounts: bool = True
 ) -> None:
     """
     Set up the sidechain.
@@ -187,7 +189,7 @@ def setup_sidechain(
 
     # set the chain's signer list and disable the master key
     # quorum is 80%
-    divide = 4 * len(params.federators)
+    divide = 4 * len(federators)
     by = 5
     quorum = (divide + by - 1) // by
     sc_chain.send_signed(
@@ -196,7 +198,7 @@ def setup_sidechain(
             signer_quorum=quorum,
             signer_entries=[
                 SignerEntry(account=federator, signer_weight=1)
-                for federator in params.federators
+                for federator in federators
             ],
         )
     )

--- a/slk/chain/chain_setup.py
+++ b/slk/chain/chain_setup.py
@@ -233,6 +233,34 @@ def setup_sidechain(
     sc_chain.maybe_ledger_accept()
 
 
+def setup_prod_mainchain(
+    mainnet_url: str,
+    mainnet_ws_port: int,
+    federators: List[str],
+    mc_door_account: Account,
+    issuer: Optional[str] = None,
+) -> None:
+    with connect_to_external_chain(
+        # TODO: stop hardcoding this
+        url=mainnet_url,
+        port=mainnet_ws_port,
+    ) as mc_chain:
+        setup_mainchain(mc_chain, federators, mc_door_account, False, issuer)
+
+
+def setup_prod_sidechain(
+    sidechain_url: str,
+    sidechain_ws_port: int,
+    federators: List[str],
+    sc_door_account: Account,
+) -> None:
+    with connect_to_external_chain(
+        url=sidechain_url,
+        port=sidechain_ws_port,
+    ) as sc_chain:
+        setup_sidechain(sc_chain, federators, sc_door_account)
+
+
 def main(
     mainnet_url: str,
     mainnet_ws_port: int,
@@ -243,18 +271,8 @@ def main(
     sc_door_account: Account,
     issuer: Optional[str] = None,
 ) -> None:
-    with connect_to_external_chain(
-        # TODO: stop hardcoding this
-        url=mainnet_url,
-        port=mainnet_ws_port,
-    ) as mc_chain:
-        setup_mainchain(mc_chain, federators, mc_door_account, False, issuer)
-
-    with connect_to_external_chain(
-        url=sidechain_url,
-        port=sidechain_ws_port,
-    ) as sc_chain:
-        setup_sidechain(sc_chain, federators, sc_door_account)
+    setup_prod_mainchain(mainnet_url, mainnet_ws_port, federators, mc_door_account, issuer)
+    setup_prod_sidechain(sidechain_url, sidechain_ws_port, federators, sc_door_account)
 
 
 # TODO: set up CLI args

--- a/slk/chain/chain_setup.py
+++ b/slk/chain/chain_setup.py
@@ -242,7 +242,7 @@ def setup_prod_mainchain(
     mainnet_url: str,
     mainnet_ws_port: int,
     federators: List[str],
-    mc_door_account: Account,
+    mc_door_account_seed: str,
     issuer: Optional[str] = None,
 ) -> None:
     """
@@ -252,10 +252,11 @@ def setup_prod_mainchain(
         mainnet_url: The URL/IP address of a node on the mainchain.
         mainnet_ws_port: The WS port of the node.
         federators: A list of the federators' public keys (for multisigning).
-        mc_door_account: The mainchain door account.
+        mc_door_account_seed: The seed of the mainchain door account.
         issuer: The issuer of a cross-chain IOU. If None, there is no cross-chain IOU.
             Default is None.
     """
+    mc_door_account = Account.from_seed(name="door", seed=mc_door_account_seed)
     with connect_to_external_chain(
         # TODO: stop hardcoding this
         url=mainnet_url,
@@ -278,7 +279,7 @@ def setup_prod_sidechain(
         sidechain_ws_port: The WS port of the node.
         federators: A list of the federators' public keys (for multisigning).
         sc_door_account: The sidechain door account. The default is the genesis
-            account.
+            account. This is the default in the sidechain code as well.
     """
     with connect_to_external_chain(
         url=sidechain_url,

--- a/slk/chain/chain_setup.py
+++ b/slk/chain/chain_setup.py
@@ -1,6 +1,6 @@
 """Helper methods for setting up chains."""
 
-from typing import List, Optional
+from typing import List
 
 from xrpl.account import does_account_exist, get_account_root
 from xrpl.clients.sync_client import SyncClient
@@ -34,7 +34,10 @@ def _is_door_master_disabled(door_acct: str, client: SyncClient) -> bool:
 
 
 def setup_mainchain(
-    mc_chain: Chain, federators: List[str], mc_door_account: str, params: SidechainParams, user_account: Optional[Account] = None
+    mc_chain: Chain,
+    federators: List[str],
+    mc_door_account: str,
+    params: SidechainParams,
 ) -> None:
     """
     Set up the mainchain.
@@ -42,15 +45,11 @@ def setup_mainchain(
     Args:
         mc_chain: The mainchain.
         params: The command-line arguments for setup.
-        setup_user_accounts: Whether to create and fund a user account and add it to
-            the list of known accounts under the name "alice". The default is True.
 
     Raises:
         Exception: If the issuer on an external network doesn't exist.
     """
     mc_chain.add_to_keymanager(mc_door_account)
-    if user_account is not None:
-        mc_chain.add_to_keymanager(user_account)
 
     # mc_chain.request(LogLevel('fatal'))
     # TODO: only do all this setup for external network if it hasn't already been done
@@ -156,20 +155,9 @@ def setup_mainchain(
     )
     mc_chain.maybe_ledger_accept()
 
-    if user_account is not None:
-        # Create and fund a regular user account
-        mc_chain.send_signed(
-            Payment(
-                account=params.genesis_account.account_id,
-                destination=user_account.account_id,
-                amount=str(2_000),
-            )
-        )
-        mc_chain.maybe_ledger_accept()
-
 
 def setup_sidechain(
-    sc_chain: Chain, federators: List[str], params: SidechainParams, user_account: Optional[Account] = None
+    sc_chain: Chain, federators: List[str], params: SidechainParams
 ) -> None:
     """
     Set up the sidechain.
@@ -177,12 +165,8 @@ def setup_sidechain(
     Args:
         sc_chain: The sidechain.
         params: The command-line arguments for setup.
-        setup_user_accounts: Whether to create and fund a user account and add it to
-            the list of known accounts under the name "alice". The default is True.
     """
     sc_chain.add_to_keymanager(params.sc_door_account)
-    if user_account is not None:
-        sc_chain.add_to_keymanager(user_account)
 
     # sc_chain.send_signed(LogLevel('fatal'))
     # sc_chain.send_signed(LogLevel('trace', partition='SidechainFederator'))

--- a/slk/chain/chain_setup.py
+++ b/slk/chain/chain_setup.py
@@ -51,7 +51,11 @@ def setup_mainchain(
 
     Args:
         mc_chain: The mainchain.
-        params: The command-line arguments for setup.
+        federators: A list of the federators' public keys (for multisigning).
+        mc_door_account: The mainchain door account.
+        main_standalone: Whether the mainchain is a standalone network.
+        issuer_seed: The seed of the issuer of a cross-chain IOU. If None, there is no
+            cross-chain IOU. Default is None.
 
     Raises:
         Exception: If the issuer on an external network doesn't exist.
@@ -177,7 +181,8 @@ def setup_sidechain(
 
     Args:
         sc_chain: The sidechain.
-        params: The command-line arguments for setup.
+        federators: A list of the federators' public keys (for multisigning).
+        sc_door_account: The sidechain door account.
     """
     sc_chain.add_to_keymanager(sc_door_account)
 
@@ -240,6 +245,17 @@ def setup_prod_mainchain(
     mc_door_account: Account,
     issuer: Optional[str] = None,
 ) -> None:
+    """
+    Set up a production mainchain.
+
+    Args:
+        mainnet_url: The URL/IP address of a node on the mainchain.
+        mainnet_ws_port: The WS port of the node.
+        federators: A list of the federators' public keys (for multisigning).
+        mc_door_account: The mainchain door account.
+        issuer: The issuer of a cross-chain IOU. If None, there is no cross-chain IOU.
+            Default is None.
+    """
     with connect_to_external_chain(
         # TODO: stop hardcoding this
         url=mainnet_url,
@@ -254,6 +270,15 @@ def setup_prod_sidechain(
     federators: List[str],
     sc_door_account: Account,
 ) -> None:
+    """
+    Set up a production sidechain.
+
+    Args:
+        sidechain_url: The URL/IP address of a node on the sidechain.
+        sidechain_ws_port: The WS port of the node.
+        federators: A list of the federators' public keys (for multisigning).
+        sc_door_account: The sidechain door account.
+    """
     with connect_to_external_chain(
         url=sidechain_url,
         port=sidechain_ws_port,
@@ -261,18 +286,24 @@ def setup_prod_sidechain(
         setup_sidechain(sc_chain, federators, sc_door_account)
 
 
-def main(
-    mainnet_url: str,
-    mainnet_ws_port: int,
-    sidechain_url: str,
-    sidechain_ws_port: int,
-    federators: List[str],
-    mc_door_account: Account,
-    sc_door_account: Account,
-    issuer: Optional[str] = None,
-) -> None:
-    setup_prod_mainchain(mainnet_url, mainnet_ws_port, federators, mc_door_account, issuer)
-    setup_prod_sidechain(sidechain_url, sidechain_ws_port, federators, sc_door_account)
+# def main(
+#     mainnet_url: str,
+#     mainnet_ws_port: int,
+#     sidechain_url: str,
+#     sidechain_ws_port: int,
+#     federators: List[str],
+#     mc_door_account: Account,
+#     sc_door_account: Account,
+#     issuer: Optional[str] = None,
+# ) -> None:
+#     """
+#     Set up a production
+#     """
+#     setup_prod_mainchain(
+#         mainnet_url, mainnet_ws_port, federators, mc_door_account, issuer
+#     )
+#     setup_prod_sidechain(sidechain_url, sidechain_ws_port, federators,
+#         sc_door_account)
 
 
 # TODO: set up CLI args

--- a/slk/chain/chain_setup.py
+++ b/slk/chain/chain_setup.py
@@ -26,6 +26,12 @@ UPDATE_SIGNER_LIST = 2
 
 _LSF_DISABLE_MASTER = 0x00100000  # 1048576
 
+_GENESIS_ACCOUNT = Account(
+    account_id="rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+    seed="snoPBrXtMeMyMHUVTgbuqAfg1SUTb",
+    nickname="genesis",
+)
+
 
 def _is_door_master_disabled(door_acct: str, client: SyncClient) -> bool:
     account_root = get_account_root(door_acct, client)
@@ -55,7 +61,7 @@ def setup_mainchain(
     # TODO: only do all this setup for external network if it hasn't already been done
 
     if params.main_standalone:
-        issuer = params.genesis_account
+        issuer = _GENESIS_ACCOUNT
     else:
         issuer = Account.from_seed("issuer", params.issuer)
         mc_chain.add_to_keymanager(issuer)
@@ -78,7 +84,7 @@ def setup_mainchain(
     if params.main_standalone:
         mc_chain.send_signed(
             Payment(
-                account=params.genesis_account.account_id,
+                account=_GENESIS_ACCOUNT.account_id,
                 destination=door_acct,
                 amount=xrp_to_drops(1_000),
             )
@@ -181,7 +187,7 @@ def setup_sidechain(
     quorum = (divide + by - 1) // by
     sc_chain.send_signed(
         SignerListSet(
-            account=params.genesis_account.account_id,
+            account=_GENESIS_ACCOUNT.account_id,
             signer_quorum=quorum,
             signer_entries=[
                 SignerEntry(account=federator, signer_weight=1)
@@ -192,7 +198,7 @@ def setup_sidechain(
     sc_chain.maybe_ledger_accept()
     sc_chain.send_signed(
         TicketCreate(
-            account=params.genesis_account.account_id,
+            account=_GENESIS_ACCOUNT.account_id,
             source_tag=MAINCHAIN_DOOR_KEEPER,
             ticket_count=1,
         )
@@ -200,7 +206,7 @@ def setup_sidechain(
     sc_chain.maybe_ledger_accept()
     sc_chain.send_signed(
         TicketCreate(
-            account=params.genesis_account.account_id,
+            account=_GENESIS_ACCOUNT.account_id,
             source_tag=SIDECHAIN_DOOR_KEEPER,
             ticket_count=1,
         )
@@ -208,7 +214,7 @@ def setup_sidechain(
     sc_chain.maybe_ledger_accept()
     sc_chain.send_signed(
         TicketCreate(
-            account=params.genesis_account.account_id,
+            account=_GENESIS_ACCOUNT.account_id,
             source_tag=UPDATE_SIGNER_LIST,
             ticket_count=1,
         )
@@ -216,7 +222,7 @@ def setup_sidechain(
     sc_chain.maybe_ledger_accept()
     sc_chain.send_signed(
         AccountSet(
-            account=params.genesis_account.account_id,
+            account=_GENESIS_ACCOUNT.account_id,
             set_flag=AccountSetFlag.ASF_DISABLE_MASTER,
         )
     )

--- a/slk/chain/chain_setup.py
+++ b/slk/chain/chain_setup.py
@@ -1,6 +1,6 @@
 """Helper methods for setting up chains."""
 
-from typing import List
+from typing import List, Optional
 
 from xrpl.account import does_account_exist, get_account_root
 from xrpl.clients.sync_client import SyncClient
@@ -43,7 +43,8 @@ def setup_mainchain(
     mc_chain: Chain,
     federators: List[str],
     mc_door_account: Account,
-    params: SidechainParams,
+    main_standalone: bool,
+    issuer: Optional[str] = None,
 ) -> None:
     """
     Set up the mainchain.
@@ -60,10 +61,10 @@ def setup_mainchain(
     # mc_chain.request(LogLevel('fatal'))
     # TODO: only do all this setup for external network if it hasn't already been done
 
-    if params.main_standalone:
+    if main_standalone:
         issuer = _GENESIS_ACCOUNT
     else:
-        issuer = Account.from_seed("issuer", params.issuer)
+        issuer = Account.from_seed("issuer", issuer)
         mc_chain.add_to_keymanager(issuer)
 
         if not does_account_exist(issuer.account_id, mc_chain.node.client):
@@ -81,7 +82,7 @@ def setup_mainchain(
     door_acct = mc_door_account.account_id
 
     # Create and fund the mc door account
-    if params.main_standalone:
+    if main_standalone:
         mc_chain.send_signed(
             Payment(
                 account=_GENESIS_ACCOUNT.account_id,

--- a/slk/sidechain_interaction.py
+++ b/slk/sidechain_interaction.py
@@ -193,7 +193,7 @@ def _chains_with_callback(
             if params.with_pauses:
                 input("Pausing after testnet start (press enter to continue)")
 
-            setup_sidechain(sc_chain, params.federators, params.sc_door_account, params)
+            setup_sidechain(sc_chain, params.federators, params.sc_door_account)
             if params.with_pauses:
                 input("Pausing after sidechain setup (press enter to continue)")
             callback(mc_chain, sc_chain)

--- a/slk/sidechain_interaction.py
+++ b/slk/sidechain_interaction.py
@@ -153,7 +153,10 @@ def _chains_with_callback(
     with mainchain as mc_chain:
         if params.with_pauses:
             input("Pausing after mainchain start (press enter to continue)")
-        setup_mainchain(mc_chain, params, setup_user_accounts)
+
+        setup_mainchain(mc_chain, params.federators, params, setup_user_accounts)
+        if params.with_pauses:
+            input("Pausing after mainchain setup (press enter to continue)")
 
         # set up/get sidechain
         if params.standalone:
@@ -190,7 +193,7 @@ def _chains_with_callback(
         with sidechain as sc_chain:
             if params.with_pauses:
                 input("Pausing after testnet start (press enter to continue)")
-            setup_sidechain(sc_chain, params, setup_user_accounts)
+            setup_sidechain(sc_chain, params.federators, params, setup_user_accounts)
             if params.with_pauses:
                 input("Pausing after sidechain setup (press enter to continue)")
             callback(mc_chain, sc_chain)

--- a/slk/sidechain_interaction.py
+++ b/slk/sidechain_interaction.py
@@ -121,7 +121,6 @@ def _convert_log_files_to_json(
 def _chains_with_callback(
     params: SidechainParams,
     callback: Callable[[Chain, Chain], None],
-    setup_user_accounts: bool = True,
 ) -> None:
     # if not params.main_standalone:
     #     _external_node_with_callback(params, callback)
@@ -154,7 +153,7 @@ def _chains_with_callback(
         if params.with_pauses:
             input("Pausing after mainchain start (press enter to continue)")
 
-        setup_mainchain(mc_chain, params.federators, params.mc_door_account, params, params.user_account if setup_user_accounts else None)
+        setup_mainchain(mc_chain, params.federators, params.mc_door_account, params)
         if params.with_pauses:
             input("Pausing after mainchain setup (press enter to continue)")
 
@@ -194,7 +193,7 @@ def _chains_with_callback(
             if params.with_pauses:
                 input("Pausing after testnet start (press enter to continue)")
 
-            setup_sidechain(sc_chain, params.federators, params, params.user_account if setup_user_accounts else None)
+            setup_sidechain(sc_chain, params.federators, params)
             if params.with_pauses:
                 input("Pausing after sidechain setup (press enter to continue)")
             callback(mc_chain, sc_chain)
@@ -260,7 +259,7 @@ def run_interactive_repl(params: SidechainParams) -> None:
                 stop_token.value = 0
                 p.join()
 
-    _chains_with_callback(params, callback, setup_user_accounts=False)
+    _chains_with_callback(params, callback)
 
 
 def main() -> None:

--- a/slk/sidechain_interaction.py
+++ b/slk/sidechain_interaction.py
@@ -193,7 +193,7 @@ def _chains_with_callback(
             if params.with_pauses:
                 input("Pausing after testnet start (press enter to continue)")
 
-            setup_sidechain(sc_chain, params.federators, params)
+            setup_sidechain(sc_chain, params.federators, params.sc_door_account, params)
             if params.with_pauses:
                 input("Pausing after sidechain setup (press enter to continue)")
             callback(mc_chain, sc_chain)

--- a/slk/sidechain_interaction.py
+++ b/slk/sidechain_interaction.py
@@ -153,7 +153,7 @@ def _chains_with_callback(
         if params.with_pauses:
             input("Pausing after mainchain start (press enter to continue)")
 
-        setup_mainchain(mc_chain, params.federators, params.mc_door_account, params)
+        setup_mainchain(mc_chain, params.federators, params.mc_door_account, True)
         if params.with_pauses:
             input("Pausing after mainchain setup (press enter to continue)")
 

--- a/slk/sidechain_interaction.py
+++ b/slk/sidechain_interaction.py
@@ -154,7 +154,7 @@ def _chains_with_callback(
         if params.with_pauses:
             input("Pausing after mainchain start (press enter to continue)")
 
-        setup_mainchain(mc_chain, params.federators, params, setup_user_accounts)
+        setup_mainchain(mc_chain, params.federators, params.mc_door_account, params, params.user_account if setup_user_accounts else None)
         if params.with_pauses:
             input("Pausing after mainchain setup (press enter to continue)")
 
@@ -193,7 +193,8 @@ def _chains_with_callback(
         with sidechain as sc_chain:
             if params.with_pauses:
                 input("Pausing after testnet start (press enter to continue)")
-            setup_sidechain(sc_chain, params.federators, params, setup_user_accounts)
+
+            setup_sidechain(sc_chain, params.federators, params, params.user_account if setup_user_accounts else None)
             if params.with_pauses:
                 input("Pausing after sidechain setup (press enter to continue)")
             callback(mc_chain, sc_chain)

--- a/tests/simple_xchain_transfer_test.py
+++ b/tests/simple_xchain_transfer_test.py
@@ -187,7 +187,7 @@ def run_sidechain_test(params: SidechainParams):
     def callback(mc_chain: Chain, sc_chain: Chain):
         run(mc_chain, sc_chain, params)
 
-    _chains_with_callback(params, callback, setup_user_accounts=False)
+    _chains_with_callback(params, callback)
 
 
 def test_simple_xchain(configs_dirs_dict: Dict[int, str]):


### PR DESCRIPTION
## High Level Overview of Change

This PR adds the ability to set up a production sidechain using the same setup scripts that the Launch Kit uses locally.

### Context of Change

The Launch Kit should also make it easy to run production sidechains, where the federators are on separate servers

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes. Works locally.
