### PR TITLE
link to rippled sidechain branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pip install sidechain-launch-kit
 
 ### Build rippled
 
-Checkout the `sidechain` branch from the rippled repository, and follow the usual process to build rippled.
+Checkout the `sidechain` branch from the [rippled repository](https://github.com/ripple/rippled/tree/sidechain), and follow the usual process to build rippled.
 
 ### Environment variables
 


### PR DESCRIPTION
## High Level Overview of Change

Adds a readme link to the rippled repo for easier access, since rippled is under a different organization and the user has to search for it on github


### Type of Change

- [x] Documentation Updates
