### PR TITLE
fix: catch and print errors in the shell instead of crashing

### DIFF
--- a/slk/repl/repl.py
+++ b/slk/repl/repl.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import binascii
 import cmd
 import json
 import os
@@ -20,6 +19,7 @@ from xrpl.models import (
     IssuedCurrencyAmount,
     Memo,
     Payment,
+    Transaction,
     TrustSet,
 )
 
@@ -42,10 +42,11 @@ def _clear_screen() -> None:
         _ = os.system("clear")
 
 
-def _file_to_hex(filename: Path) -> str:
-    with open(filename, "rb") as f:
-        content = f.read()
-    return binascii.hexlify(content).decode("utf8")
+def _send_signed_catch_error(chain: Chain, tx: Transaction) -> None:
+    try:
+        chain.send_signed(tx)
+    except Exception as e:
+        print(repr(e))
 
 
 class SidechainRepl(cmd.Cmd):
@@ -592,12 +593,13 @@ class SidechainRepl(cmd.Cmd):
             amt = str(amt_value)
 
         # TODO: print error if something wrong with payment (e.g. no trustline)
-        chain.send_signed(
+        _send_signed_catch_error(
+            chain,
             Payment(
                 account=src_account.account_id,
                 destination=dst_account.account_id,
                 amount=amt,
-            )
+            ),
         )
         chain.maybe_ledger_accept()
 
@@ -758,13 +760,14 @@ class SidechainRepl(cmd.Cmd):
 
         memos = [Memo(memo_data=dst_account.account_id_str_as_hex())]
         door_account = chain.account_from_alias("door")
-        chain.send_signed(
+        _send_signed_catch_error(
+            chain,
             Payment(
                 account=src_account.account_id,
                 destination=door_account.account_id,
                 amount=amt,
                 memos=memos,
-            )
+            ),
         )
         chain.maybe_ledger_accept()
         if other_chain.standalone:
@@ -1293,7 +1296,9 @@ class SidechainRepl(cmd.Cmd):
 
         asset = chain.asset_from_alias(alias).to_amount(amount)
         # TODO: resolve error where repl crashes if account doesn't exist
-        chain.send_signed(TrustSet(account=account.account_id, limit_amount=asset))
+        _send_signed_catch_error(
+            chain, TrustSet(account=account.account_id, limit_amount=asset)
+        )
         chain.maybe_ledger_accept()
 
     def complete_set_trust(

--- a/slk/repl/repl.py
+++ b/slk/repl/repl.py
@@ -592,7 +592,6 @@ class SidechainRepl(cmd.Cmd):
         else:
             amt = str(amt_value)
 
-        # TODO: print error if something wrong with payment (e.g. no trustline)
         _send_signed_catch_error(
             chain,
             Payment(
@@ -1255,7 +1254,6 @@ class SidechainRepl(cmd.Cmd):
         Args:
             line: The command-line arguments.
         """
-        # TODO: fix bug where REPL crashes if account isn't funded yet
         args = line.split()
         if len(args) != 4:
             print(
@@ -1295,7 +1293,6 @@ class SidechainRepl(cmd.Cmd):
             return
 
         asset = chain.asset_from_alias(alias).to_amount(amount)
-        # TODO: resolve error where repl crashes if account doesn't exist
         _send_signed_catch_error(
             chain, TrustSet(account=account.account_id, limit_amount=asset)
         )


### PR DESCRIPTION
## High Level Overview of Change

This PR wraps the sign-and-submit calls in the REPL so that if an error occurs, it is caught and printed out instead of being allowed to run wild and crash the shell.

### Context of Change

The shell would crash if it had an error in the sign-and-submit process (either a bad transaction or an error returned from rippled).

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

Before, the shell would crash when it had an error.

```
Welcome to the sidechain shell.   Type help or ? to list commands.

SSX> balance
 account   |               balance | currency   | peer   | limit
-----------+-----------------------+------------+--------+---------
 main root | 99,999,998,999.999985 | XRP        |        |
 main door |            999.999940 | XRP        |        |
 side door | 99,999,999,999.999954 | XRP        |        |
SSX> new_account mainchain alice
SSX> pay mainchain root alice -30
XRPLBinaryCodecException('Error processing Amount: -30000000 is an invalid XRP amount.')
SSX>



## Test Plan

Works when tested locally.
