### PR TITLE
fix: stop repeating commands with an empty line in the shell

### DIFF
--- a/slk/repl/repl.py
+++ b/slk/repl/repl.py
@@ -59,6 +59,17 @@ class SidechainRepl(cmd.Cmd):
         """Clear the screen before the REPL starts up."""
         _clear_screen()
 
+    def emptyline(self: SidechainRepl) -> bool:
+        """
+        Method called when an empty line is entered in response to the prompt. If this
+        method is not overridden, it repeats the last nonempty command entered. This
+        method is overridden so that it does nothing instead of repeating commands.
+
+        Returns:
+            False. Returning True would shut down the shell.
+        """
+        return False
+
     def __init__(self: SidechainRepl, mc_chain: Chain, sc_chain: Chain) -> None:
         """
         Initialize the sidechain REPL.


### PR DESCRIPTION
## High Level Overview of Change

Previously, the shell would automatically repeat the previous command if you hit `Enter` on an empty line. Now, it does nothing.

### Context of Change

Users may find the old behavior annoying and might accidentally re-apply transactions that they don't want.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

New behavior:
```
Welcome to the sidechain shell.   Type help or ? to list commands.

SSX> balance
 account   |               balance | currency   | peer   | limit
-----------+-----------------------+------------+--------+---------
 main root | 99,999,998,999.999985 | XRP        |        |
 main door |            999.999940 | XRP        |        |
 side door | 99,999,999,999.999954 | XRP        |        |
SSX> 
SSX> 
SSX> 
SSX>
```

## Test Plan

Tested locally, worked as expected.
