### PR TITLE
fix: decimal precision issue with `balance` shell command

### DIFF
--- a/slk/repl/repl.py
+++ b/slk/repl/repl.py
@@ -362,7 +362,6 @@ class SidechainRepl(cmd.Cmd):
         assert arg_index == len(args)
 
         result = get_balances_data(chains, chain_names, account_ids, assets, in_drops)
-        print(result)
         print(
             tabulate(
                 result,
@@ -370,6 +369,7 @@ class SidechainRepl(cmd.Cmd):
                 tablefmt="presto",
                 floatfmt=",.6f",
                 numalign="right",
+                colalign=("left", "right"),
             )
         )
 

--- a/slk/repl/repl.py
+++ b/slk/repl/repl.py
@@ -362,6 +362,7 @@ class SidechainRepl(cmd.Cmd):
         assert arg_index == len(args)
 
         result = get_balances_data(chains, chain_names, account_ids, assets, in_drops)
+        print(result)
         print(
             tabulate(
                 result,

--- a/slk/repl/repl.py
+++ b/slk/repl/repl.py
@@ -349,7 +349,8 @@ class SidechainRepl(cmd.Cmd):
             elif not chains[0].is_asset_alias(asset_alias):
                 print(f"Error: {asset_alias} is not a valid asset alias")
                 return
-            assets = [[chains[0].asset_from_alias(asset_alias)]]
+            else:
+                assets = [[chains[0].asset_from_alias(asset_alias)]]
         else:
             # XRP and all assets in the assets alias list
             assets = [

--- a/slk/repl/repl_functionality.py
+++ b/slk/repl/repl_functionality.py
@@ -157,7 +157,7 @@ def get_federator_info(
                 for t in pending:
                     amt = t["amount"]
                     if is_xrp(amt):
-                        amt = drops_to_xrp(amt)
+                        amt = format(drops_to_xrp(amt), ",.6f")
                     if not verbose:
                         pending_info = {
                             "chain": short_chain_name,
@@ -304,14 +304,18 @@ def get_balances_data(
     result = []
     for chain, chain_name, acc, asset in zip(chains, chain_names, account_ids, assets):
         chain_result = chain.get_balances(acc, asset)
+        print(chain_result)
         for chain_res in chain_result:
             chain.substitute_nicknames(chain_res)
             if not in_drops and chain_res["currency"] == "XRP":
+                print(chain_res["balance"], drops_to_xrp(chain_res["balance"]))
                 chain_res["balance"] = drops_to_xrp(chain_res["balance"])
+                chain_res["balance"] = format(chain_res["balance"], ",.6f")
             else:
                 try:
                     chain_res["balance"] = int(chain_res["balance"])
                 except ValueError:
+                    print(chain_res["balance"], float(chain_res["balance"]))
                     chain_res["balance"] = float(chain_res["balance"])
             chain_short_name = "main" if chain_name == "mainchain" else "side"
             chain_res["account"] = chain_short_name + " " + chain_res["account"]

--- a/slk/repl/repl_functionality.py
+++ b/slk/repl/repl_functionality.py
@@ -157,7 +157,7 @@ def get_federator_info(
                 for t in pending:
                     amt = t["amount"]
                     if is_xrp(amt):
-                        amt = format(drops_to_xrp(amt), ",.6f")
+                        amt = drops_to_xrp(amt)
                     if not verbose:
                         pending_info = {
                             "chain": short_chain_name,
@@ -308,6 +308,8 @@ def get_balances_data(
             chain.substitute_nicknames(chain_res)
             if not in_drops and chain_res["currency"] == "XRP":
                 chain_res["balance"] = drops_to_xrp(chain_res["balance"])
+                # TODO: do this in a neater way (by removing this extra formatting)
+                # when https://github.com/astanin/python-tabulate/pull/176 is approved
                 chain_res["balance"] = format(chain_res["balance"], ",.6f")
             else:
                 try:

--- a/slk/repl/repl_functionality.py
+++ b/slk/repl/repl_functionality.py
@@ -304,18 +304,15 @@ def get_balances_data(
     result = []
     for chain, chain_name, acc, asset in zip(chains, chain_names, account_ids, assets):
         chain_result = chain.get_balances(acc, asset)
-        print(chain_result)
         for chain_res in chain_result:
             chain.substitute_nicknames(chain_res)
             if not in_drops and chain_res["currency"] == "XRP":
-                print(chain_res["balance"], drops_to_xrp(chain_res["balance"]))
                 chain_res["balance"] = drops_to_xrp(chain_res["balance"])
                 chain_res["balance"] = format(chain_res["balance"], ",.6f")
             else:
                 try:
                     chain_res["balance"] = int(chain_res["balance"])
                 except ValueError:
-                    print(chain_res["balance"], float(chain_res["balance"]))
                     chain_res["balance"] = float(chain_res["balance"])
             chain_short_name = "main" if chain_name == "mainchain" else "side"
             chain_res["account"] = chain_short_name + " " + chain_res["account"]


### PR DESCRIPTION
## High Level Overview of Change

The precision was incorrect for the balance of the accounts in the `balance` output. This PR fixes that precision issue. It would also be resolved by https://github.com/astanin/python-tabulate/pull/176, but that will take longer to be approved.

### Context of Change

Reported by @sgramkumar 

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

Before:
```
SSX> balance
 account   |               balance | currency   | peer   | limit
-----------+-----------------------+------------+--------+---------
 main root | 99,999,998,999.999985 | XRP        |        |
 main door |            999.999940 | XRP        |        |
 side door | 99,999,999,999.999954 | XRP        |        |
```

After:
```
SSX> balance
 account   |               balance | currency   | peer   | limit
-----------+-----------------------+------------+--------+---------
 main root | 99,999,998,999.999980 | XRP        |        |
 main door |            999.999940 | XRP        |        |
 side door | 99,999,999,999.999950 | XRP        |        |

```

## Test Plan

Tested manually, it works properly.
