### PR TITLE
fix: resolve issues with stopped servers

### DIFF
--- a/slk/chain/chain.py
+++ b/slk/chain/chain.py
@@ -44,12 +44,23 @@ class Chain(ABC):
             add_root: Specifies if the root account should be added to the key manager.
                 The default is True.
         """
-        self.node = node
+        self._node = node
         self.key_manager = KeyManager()
         self.asset_aliases = AssetAliases()
 
         if add_root:
             self.key_manager.add(ROOT_ACCOUNT)
+
+    @property
+    def node(self: Chain) -> Node:
+        """
+        The node to interact with to fetch information from the chain.
+
+        Returns:
+            The node to interact with.
+        """
+        # TODO: refactor so this uses a client instead of a node
+        return self._node
 
     @property
     @abstractmethod

--- a/slk/chain/chain.py
+++ b/slk/chain/chain.py
@@ -58,8 +58,11 @@ class Chain(ABC):
         pass
 
     @abstractmethod
-    def get_pids(self: Chain) -> List[int]:
-        """Return a list of process IDs for the nodes in the chain."""
+    def get_pids(self: Chain) -> List[Optional[int]]:
+        """
+        Return a list of process IDs for all the nodes in the chain (return None if the
+        node is not running).
+        """
         pass
 
     @abstractmethod

--- a/slk/chain/external_chain.py
+++ b/slk/chain/external_chain.py
@@ -40,7 +40,7 @@ class ExternalChain(Chain):
         """
         return False
 
-    def get_pids(self: ExternalChain) -> List[int]:
+    def get_pids(self: ExternalChain) -> List[Optional[int]]:
         """
         Return a list of process IDs for the nodes in the chain.
 

--- a/slk/chain/mainchain.py
+++ b/slk/chain/mainchain.py
@@ -58,7 +58,7 @@ class Mainchain(Chain):
         """
         return True
 
-    def get_pids(self: Mainchain) -> List[int]:
+    def get_pids(self: Mainchain) -> List[Optional[int]]:
         """
         Return a list of process IDs for the nodes in the chain.
 

--- a/slk/chain/node.py
+++ b/slk/chain/node.py
@@ -220,7 +220,7 @@ class Node:
             A dictionary of the server_state, validated_ledger_seq, and
             complete_ledgers for the node.
         """
-        ret = {"server_state": "NA", "ledger_seq": "NA", "complete_ledgers": "NA"}
+        ret = {"server_state": "", "ledger_seq": "", "complete_ledgers": ""}
         if not self.running:
             return ret
         r = self.client.request(ServerInfo()).result

--- a/slk/chain/sidechain.py
+++ b/slk/chain/sidechain.py
@@ -99,14 +99,16 @@ class Sidechain(Chain):
         """
         return False
 
-    def get_pids(self: Sidechain) -> List[int]:
+    def get_pids(self: Sidechain) -> List[Optional[int]]:
         """
-        Return a list of process IDs for the nodes in the chain.
+        Return a list of process IDs for all the nodes in the chain (return None if the
+        node is not running).
 
         Returns:
-            A list of process IDs for the nodes in the chain.
+            A list of process IDs for the nodes in the chain (None if the node isn't
+                running).
         """
-        return [pid for c in self.nodes if (pid := c.get_pid()) is not None]
+        return [c.get_pid() for c in self.nodes]
 
     # TODO: type this better
     def get_node(self: Sidechain, i: Optional[int] = None) -> Node:

--- a/slk/chain/sidechain.py
+++ b/slk/chain/sidechain.py
@@ -89,6 +89,22 @@ class Sidechain(Chain):
         self.servers_start()
 
     @property
+    def node(self: Sidechain) -> Node:
+        """
+        The node to interact with to fetch information from the chain.
+
+        Returns:
+            The node to interact with.
+
+        Raises:
+            Exception: if there are no nodes running.
+        """
+        for node in self.nodes:
+            if node.running:
+                return node
+        raise Exception("No nodes running")
+
+    @property
     def standalone(self: Sidechain) -> bool:
         """
         Return whether the chain is in standalone mode.
@@ -209,18 +225,18 @@ class Sidechain(Chain):
         if server_indexes is None:
             server_indexes = self.running_server_indexes.copy()
 
-        if 0 in server_indexes:
-            print(
-                "WARNING: Server 0 is being stopped. RPC commands cannot be sent until "
-                "this is restarted."
-            )
-
         for i in server_indexes:
             if i not in self.running_server_indexes:
                 continue
             node = self.nodes[i]
             node.stop_server()
             self.running_server_indexes.discard(i)
+
+        if len(self.running_server_indexes) == 0:
+            print(
+                "WARNING: All servers are stopped. RPC commands cannot be sent "
+                "until this is restarted."
+            )
 
     def get_brief_server_info(self: Sidechain) -> Dict[str, List[Dict[str, Any]]]:
         """

--- a/slk/chain/sidechain.py
+++ b/slk/chain/sidechain.py
@@ -167,9 +167,8 @@ class Sidechain(Chain):
 
     def shutdown(self: Sidechain) -> None:
         """Shut down the chain."""
-        for a in self.nodes:
-            if a.running:
-                a.shutdown()
+        for node in self.nodes:
+            node.shutdown()
 
         self.servers_stop()
 

--- a/slk/chain/sidechain.py
+++ b/slk/chain/sidechain.py
@@ -152,7 +152,8 @@ class Sidechain(Chain):
     def shutdown(self: Sidechain) -> None:
         """Shut down the chain."""
         for a in self.nodes:
-            a.shutdown()
+            if a.running:
+                a.shutdown()
 
         self.servers_stop()
 

--- a/slk/repl/repl_functionality.py
+++ b/slk/repl/repl_functionality.py
@@ -67,14 +67,12 @@ def get_server_info(
         chains = []
         for i in range(len(filenames)):
             chains.append(f"{chain_name} {i}")
-        data: Dict[str, Any] = {"node": chains}
-        data.update(
-            {
-                "pid": chain.get_pids(),
-                "config": filenames,
-                "running": chain.get_running_status(),
-            }
-        )
+        data: Dict[str, Any] = {
+            "node": chains,
+            "pid": chain.get_pids(),
+            "config": filenames,
+            "running": chain.get_running_status(),
+        }
         bsi = chain.get_brief_server_info()
         data.update(bsi)
         return data


### PR DESCRIPTION
## High Level Overview of Change

This PR fixes several issues with servers not stopping properly/crashing when stopped.

It resolves:
* You can now run shell commands even when server 0 is stopped
* `server_info` doesn't crash when a server has been stopped

### Context of Change

Reported issue, plus other issues discovered while fixing it

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes.
